### PR TITLE
Add test case for missing operator

### DIFF
--- a/expression.go
+++ b/expression.go
@@ -62,7 +62,7 @@ type FalseExpr struct {
 }
 
 func (expr FalseExpr) String() string {
-	return "True"
+	return "False"
 }
 
 func (expr FalseExpr) RootRefs() []FieldExpr {


### PR DESCRIPTION
The ">" (greater than) and "<=" (less than or equal) are defined but
not implemented

    --- FAIL: TestParserExpressionWithGreaterThan (0.00s)
    	simpleParser_test.go:734:
    			Error Trace:	simpleParser_test.go:734
    			Error:      	Expected nil, but got: &errors.errorString{s:"Error: Invalid op type: >"}
    			Test:       	TestParserExpressionWithGreaterThan