### PR TITLE
Fixes #6: Update mergeExpr's to match all expressions.

### DIFF
--- a/bintree.go
+++ b/bintree.go
@@ -15,6 +15,7 @@ const (
 	nodeTypeOr
 	nodeTypeAnd
 	nodeTypeNot
+	nodeTypeNeor
 )
 
 func binTreeNodeTypeToString(nodeType BinTreeNodeType) string {
@@ -27,6 +28,8 @@ func binTreeNodeTypeToString(nodeType BinTreeNodeType) string {
 		return "and"
 	case nodeTypeNot:
 		return "not"
+	case nodeTypeNeor:
+		return "neor"
 	}
 	return "??ERROR??"
 }
@@ -155,6 +158,7 @@ func (tree *binTree) validateItem(item int, parent int) (int, error) {
 	case nodeTypeAnd:
 	case nodeTypeOr:
 	case nodeTypeNot:
+	case nodeTypeNeor:
 	default:
 		// Invalid node type
 		return -1, errors.New("unexpected node type")
@@ -286,6 +290,15 @@ func (state *binTreeState) checkNode(index int) {
 			state.MarkNode(index, true)
 		} else if state.data[defNode.Left] == binTreeStateFalse && state.data[defNode.Right] == binTreeStateFalse {
 			state.MarkNode(index, false)
+		}
+		return
+	} else if defNode.NodeType == nodeTypeNeor {
+		if state.data[defNode.Left] != binTreeStateUnknown && state.data[defNode.Right] != binTreeStateUnknown {
+			if state.data[defNode.Left] == binTreeStateTrue || state.data[defNode.Right] == binTreeStateTrue {
+				state.MarkNode(index, true)
+			} else {
+				state.MarkNode(index, false)
+			}
 		}
 		return
 	} else if defNode.NodeType == nodeTypeAnd {

--- a/transform.go
+++ b/transform.go
@@ -290,7 +290,7 @@ func (t *Transformer) transformMergePiece(expr mergeExpr, i int) *ExecNode {
 	}
 
 	baseBucketIdx := t.ActiveBucketIdx
-	t.RootTree.data[baseBucketIdx].NodeType = nodeTypeOr
+	t.RootTree.data[baseBucketIdx].NodeType = nodeTypeNeor
 
 	t.newBucket()
 	expr.bucketIDs[i] = t.ActiveBucketIdx


### PR DESCRIPTION
A bug existed in the original mergeExpr implementation where
it would generate an OR in the binary tree, causing the
matcher to short-circuit without evaluating other expressions
as soon as a single one of the merged expressions matched.