### PR TITLE
SimpleParser NOT and other operations

### DIFF
--- a/expression.go
+++ b/expression.go
@@ -254,16 +254,16 @@ func (expr LessThanExpr) RootRefs() []FieldExpr {
 	return out
 }
 
-type GreaterEqualExpr struct {
+type GreaterThanExpr struct {
 	Lhs Expression
 	Rhs Expression
 }
 
-func (expr GreaterEqualExpr) String() string {
-	return fmt.Sprintf("%s >= %s", expr.Lhs, expr.Rhs)
+func (expr GreaterThanExpr) String() string {
+	return fmt.Sprintf("%s > %s", expr.Lhs, expr.Rhs)
 }
 
-func (expr GreaterEqualExpr) RootRefs() []FieldExpr {
+func (expr GreaterThanExpr) RootRefs() []FieldExpr {
 	var out []FieldExpr
 	out = rootSetAdd(out, expr.Lhs.RootRefs()...)
 	out = rootSetAdd(out, expr.Rhs.RootRefs()...)

--- a/expression_json.go
+++ b/expression_json.go
@@ -79,15 +79,15 @@ func parseJsonLessThan(data []interface{}) (Expression, error) {
 	return LessThanExpr{lhs, rhs}, nil
 }
 
-func parseJsonGreaterEquals(data []interface{}) (Expression, error) {
+func parseJsonGreaterThan(data []interface{}) (Expression, error) {
 	lhsData, ok := data[1].([]interface{})
 	if !ok {
-		return nil, errors.New("invalid greaterequals expression lhs format")
+		return nil, errors.New("invalid greaterthan expression lhs format")
 	}
 
 	rhsData, ok := data[2].([]interface{})
 	if !ok {
-		return nil, errors.New("invalid greaterequals expression rhs format")
+		return nil, errors.New("invalid greaterthan expression rhs format")
 	}
 
 	lhs, err := parseJsonSubexpr(lhsData)
@@ -100,7 +100,7 @@ func parseJsonGreaterEquals(data []interface{}) (Expression, error) {
 		return nil, err
 	}
 
-	return GreaterEqualExpr{lhs, rhs}, nil
+	return GreaterThanExpr{lhs, rhs}, nil
 }
 
 func parseJsonNot(data []interface{}) (Expression, error) {
@@ -241,8 +241,8 @@ func parseJsonSubexpr(data []interface{}) (Expression, error) {
 		return parseJsonEquals(data)
 	case "lessthan":
 		return parseJsonLessThan(data)
-	case "greaterequal":
-		return parseJsonGreaterEquals(data)
+	case "greaterthan":
+		return parseJsonGreaterThan(data)
 	case "not":
 		return parseJsonNot(data)
 	}

--- a/expression_json.go
+++ b/expression_json.go
@@ -243,8 +243,6 @@ func parseJsonSubexpr(data []interface{}) (Expression, error) {
 		return parseJsonLessThan(data)
 	case "greaterthan":
 		return parseJsonGreaterThan(data)
-	case "not":
-		return parseJsonNot(data)
 	}
 
 	return nil, errors.New("invalid expression type")

--- a/expression_json.go
+++ b/expression_json.go
@@ -243,6 +243,8 @@ func parseJsonSubexpr(data []interface{}) (Expression, error) {
 		return parseJsonLessThan(data)
 	case "greaterequal":
 		return parseJsonGreaterEquals(data)
+	case "not":
+		return parseJsonNot(data)
 	}
 
 	return nil, errors.New("invalid expression type")

--- a/expressionstats.go
+++ b/expressionstats.go
@@ -66,7 +66,7 @@ func (stats *ExpressionStats) scanOne(expr Expression, loopDepth int) error {
 	case LessThanExpr:
 		stats.scanOne(expr.Lhs, loopDepth)
 		stats.scanOne(expr.Rhs, loopDepth)
-	case GreaterEqualExpr:
+	case GreaterThanExpr:
 		stats.scanOne(expr.Lhs, loopDepth)
 		stats.scanOne(expr.Rhs, loopDepth)
 	default:

--- a/matcher.go
+++ b/matcher.go
@@ -366,6 +366,7 @@ func (m *Matcher) Match(data []byte) (bool, error) {
 		return false, err
 	}
 
+	//	fmt.Printf("Parse node: %v\n", m.def.ParseNode)
 	err = m.matchExec(token, tokenData, m.def.ParseNode)
 	if err != nil {
 		return false, err

--- a/matcher.go
+++ b/matcher.go
@@ -128,8 +128,8 @@ func (m *Matcher) matchExec(token tokenType, tokenData []byte, node *ExecNode) e
 					opRes = litVal.Equals(opVal)
 				} else if op.Op == OpTypeLessThan {
 					opRes = litVal.Compare(opVal) < 0
-				} else if op.Op == OpTypeGreaterEquals {
-					opRes = litVal.Compare(opVal) >= 0
+				} else if op.Op == OpTypeGreaterThan {
+					opRes = litVal.Compare(opVal) > 0
 				} else {
 					panic("invalid op type")
 				}

--- a/matcher.go
+++ b/matcher.go
@@ -366,7 +366,6 @@ func (m *Matcher) Match(data []byte) (bool, error) {
 		return false, err
 	}
 
-	//	fmt.Printf("Parse node: %v\n", m.def.ParseNode)
 	err = m.matchExec(token, tokenData, m.def.ParseNode)
 	if err != nil {
 		return false, err

--- a/simpleParser.go
+++ b/simpleParser.go
@@ -713,6 +713,8 @@ func (ctx *expressionParserContext) outputOp(node ParserTreeNode, pos int) (Expr
 	switch nodeData {
 	case TokenOperatorEqual:
 		return ctx.outputEq(node, pos)
+	case TokenOperatorNotEqual:
+		return ctx.outputNotEq(node, pos)
 	case TokenOperatorOr:
 		return ctx.outputOr(node, pos)
 	case TokenOperatorAnd:
@@ -786,6 +788,19 @@ func (ctx *expressionParserContext) outputEq(node ParserTreeNode, pos int) (Expr
 
 	out.Lhs = leftSubExpr
 	out.Rhs = rightSubExpr
+
+	return out, nil
+}
+
+func (ctx *expressionParserContext) outputNotEq(node ParserTreeNode, pos int) (Expression, error) {
+	var out NotExpr
+
+	subEqualExpr, err := ctx.outputEq(node, pos)
+	if err != nil {
+		return out, err
+	}
+
+	out.SubExpr = subEqualExpr
 
 	return out, nil
 }

--- a/simpleParser.go
+++ b/simpleParser.go
@@ -719,13 +719,14 @@ func (ctx *expressionParserContext) outputOp(node ParserTreeNode, pos int) (Expr
 		return ctx.outputOr(node, pos)
 	case TokenOperatorAnd:
 		return ctx.outputAnd(node, pos)
-	case TokenOperatorGreaterThanEq:
-		return nil, nil // TODO
-		//		return ctx.outputGreaterEquals(node, pos)
 	case TokenOperatorLessThan:
 		return ctx.outputLessThan(node, pos)
 	case TokenOperatorGreaterThan:
 		return ctx.outputGreaterThan(node, pos)
+	case TokenOperatorGreaterThanEq:
+		return ctx.outputGreaterEq(node, pos)
+	case TokenOperatorLessThanEq:
+		return ctx.outputLessThanEq(node, pos)
 	default:
 		return emptyExpression, fmt.Errorf("Error: Invalid op type: %s", nodeData)
 	}
@@ -753,6 +754,20 @@ func (ctx *expressionParserContext) outputGreaterThan(node ParserTreeNode, pos i
 	return out, nil
 }
 
+func (ctx *expressionParserContext) outputGreaterEq(node ParserTreeNode, pos int) (Expression, error) {
+	var out NotExpr
+
+	// >= is the inverse of <
+	subLessThanExpr, err := ctx.outputLessThan(node, pos)
+	if err != nil {
+		return out, err
+	}
+
+	out.SubExpr = subLessThanExpr
+
+	return out, nil
+}
+
 func (ctx *expressionParserContext) outputLessThan(node ParserTreeNode, pos int) (Expression, error) {
 	var out LessThanExpr
 	leftNode, leftPos := ctx.getLeftOutputNode(pos)
@@ -770,6 +785,20 @@ func (ctx *expressionParserContext) outputLessThan(node ParserTreeNode, pos int)
 
 	out.Lhs = leftSubExpr
 	out.Rhs = rightSubExpr
+
+	return out, nil
+}
+
+func (ctx *expressionParserContext) outputLessThanEq(node ParserTreeNode, pos int) (Expression, error) {
+	var out NotExpr
+
+	// <= is the inverse of >
+	subGreaterThan, err := ctx.outputGreaterThan(node, pos)
+	if err != nil {
+		return out, err
+	}
+
+	out.SubExpr = subGreaterThan
 
 	return out, nil
 }

--- a/simpleParser.go
+++ b/simpleParser.go
@@ -720,17 +720,20 @@ func (ctx *expressionParserContext) outputOp(node ParserTreeNode, pos int) (Expr
 	case TokenOperatorAnd:
 		return ctx.outputAnd(node, pos)
 	case TokenOperatorGreaterThanEq:
-		return ctx.outputGreaterEquals(node, pos)
+		return nil, nil // TODO
+		//		return ctx.outputGreaterEquals(node, pos)
 	case TokenOperatorLessThan:
 		return ctx.outputLessThan(node, pos)
+	case TokenOperatorGreaterThan:
+		return ctx.outputGreaterThan(node, pos)
 	default:
 		return emptyExpression, fmt.Errorf("Error: Invalid op type: %s", nodeData)
 	}
 }
 
 // Various outputOp types methods
-func (ctx *expressionParserContext) outputGreaterEquals(node ParserTreeNode, pos int) (Expression, error) {
-	var out GreaterEqualExpr
+func (ctx *expressionParserContext) outputGreaterThan(node ParserTreeNode, pos int) (Expression, error) {
+	var out GreaterThanExpr
 	leftNode, leftPos := ctx.getLeftOutputNode(pos)
 	rightNode, rightPos := ctx.getRightOutputNode(pos)
 

--- a/simpleParser_test.go
+++ b/simpleParser_test.go
@@ -241,7 +241,6 @@ func TestSimpleParserSubContext6(t *testing.T) {
 	node := ctx.parserDataNodes[ctx.subCtx.lastParserDataNode]
 	assert.NotNil(node)
 
-	//	fmt.Printf("DEBUG tree: %v\n", ctx.parserTree.data)
 	assert.Equal(3, ctx.parserTree.data[1].ParentIdx)
 	assert.Equal(0, ctx.parserTree.data[1].Left)
 	assert.Equal(2, ctx.parserTree.data[1].Right)
@@ -546,7 +545,6 @@ func TestParserExpressionOutputNot(t *testing.T) {
 	assert.NotNil(matchDef)
 
 	m := NewMatcher(matchDef)
-	//	fmt.Printf("NEIL DEBUG matchDef tree: %v\n", matchDef.MatchTree.data)
 
 	userData := map[string]interface{}{
 		"name": map[string]interface{}{
@@ -655,9 +653,245 @@ func TestParserExpressionOutputNot3(t *testing.T) {
 	}
 	match, err := m.Match(udMarsh)
 	assert.Nil(err)
-	assert.False(match)
+	assert.True(match)
 
 	strExpr := "name.first == 'David' || (age < 50 && isActive != true)"
+
+	ctx, err := NewExpressionParserCtx(strExpr)
+	assert.Nil(err)
+
+	err = ctx.parse()
+	assert.Nil(err)
+
+	simpleExpr, err := ctx.outputExpression()
+	assert.Nil(err)
+
+	assert.Equal(jsonExpr.String(), simpleExpr.String())
+}
+
+func TestParserExpressionOutputGreaterThan(t *testing.T) {
+	assert := assert.New(t)
+
+	matchJson := []byte(`
+	["or",
+	  ["equals",
+	    ["field", "name", "first"],
+	    ["value", "David"]
+	  ],
+	  ["and",
+	    ["greaterthan",
+	      ["field", "age"],
+	      ["value", 50]
+	    ],
+	    ["equals",
+	      ["field", "isActive"],
+	      ["value", true]
+	    ]
+	  ]
+    ]`)
+
+	jsonExpr, err := ParseJsonExpression(matchJson)
+	assert.Nil(err)
+
+	var trans Transformer
+	matchDef := trans.Transform([]Expression{jsonExpr})
+	assert.NotNil(matchDef)
+
+	m := NewMatcher(matchDef)
+
+	userData := map[string]interface{}{
+		"name": map[string]interface{}{
+			"first": "Goliath",
+		},
+		"isActive": true,
+		"age":      51,
+	}
+	udMarsh, err := json.Marshal(userData)
+	if err != nil {
+	}
+	match, err := m.Match(udMarsh)
+	assert.Nil(err)
+	assert.True(match)
+
+	strExpr := "name.first == 'David' || (age > 50 && isActive == true)"
+
+	ctx, err := NewExpressionParserCtx(strExpr)
+	assert.Nil(err)
+
+	err = ctx.parse()
+	assert.Nil(err)
+
+	simpleExpr, err := ctx.outputExpression()
+	assert.Nil(err)
+
+	assert.Equal(jsonExpr.String(), simpleExpr.String())
+}
+
+func TestParserExpressionOutputGreaterThanEquals(t *testing.T) {
+	assert := assert.New(t)
+
+	matchJson := []byte(`
+	["or",
+	  ["equals",
+	    ["field", "name", "first"],
+	    ["value", "David"]
+	  ],
+	  ["and",
+		["not",
+	      ["lessthan",
+	        ["field", "age"],
+	        ["value", 50]
+	      ]
+	    ],
+	    ["equals",
+	      ["field", "isActive"],
+	      ["value", true]
+	    ]
+	  ]
+    ]`)
+
+	jsonExpr, err := ParseJsonExpression(matchJson)
+	assert.Nil(err)
+
+	var trans Transformer
+	matchDef := trans.Transform([]Expression{jsonExpr})
+	assert.NotNil(matchDef)
+
+	m := NewMatcher(matchDef)
+
+	userData := map[string]interface{}{
+		"name": map[string]interface{}{
+			"first": "Goliath",
+		},
+		"isActive": true,
+		"age":      50,
+	}
+	udMarsh, err := json.Marshal(userData)
+	if err != nil {
+	}
+	match, err := m.Match(udMarsh)
+	assert.Nil(err)
+	assert.True(match)
+
+	strExpr := "name.first == 'David' || (age >= 50 && isActive == true)"
+
+	ctx, err := NewExpressionParserCtx(strExpr)
+	assert.Nil(err)
+
+	err = ctx.parse()
+	assert.Nil(err)
+
+	simpleExpr, err := ctx.outputExpression()
+	assert.Nil(err)
+
+	assert.Equal(jsonExpr.String(), simpleExpr.String())
+}
+
+func TestParserExpressionOutputLessThan(t *testing.T) {
+	assert := assert.New(t)
+
+	matchJson := []byte(`
+	["or",
+	  ["equals",
+	    ["field", "name", "first"],
+	    ["value", "David"]
+	  ],
+	  ["and",
+	    ["lessthan",
+	      ["field", "age"],
+	      ["value", 50]
+	    ],
+	    ["equals",
+	      ["field", "isActive"],
+	      ["value", true]
+	    ]
+	  ]
+    ]`)
+
+	jsonExpr, err := ParseJsonExpression(matchJson)
+	assert.Nil(err)
+
+	var trans Transformer
+	matchDef := trans.Transform([]Expression{jsonExpr})
+	assert.NotNil(matchDef)
+
+	m := NewMatcher(matchDef)
+
+	userData := map[string]interface{}{
+		"name": map[string]interface{}{
+			"first": "Goliath",
+		},
+		"isActive": true,
+		"age":      49,
+	}
+	udMarsh, err := json.Marshal(userData)
+	if err != nil {
+	}
+	match, err := m.Match(udMarsh)
+	assert.Nil(err)
+	assert.True(match)
+
+	strExpr := "name.first == 'David' || (age < 50 && isActive == true)"
+
+	ctx, err := NewExpressionParserCtx(strExpr)
+	assert.Nil(err)
+
+	err = ctx.parse()
+	assert.Nil(err)
+
+	simpleExpr, err := ctx.outputExpression()
+	assert.Nil(err)
+
+	assert.Equal(jsonExpr.String(), simpleExpr.String())
+}
+
+func TestParserExpressionOutputLessThanEq(t *testing.T) {
+	assert := assert.New(t)
+
+	matchJson := []byte(`
+	["or",
+	  ["equals",
+	    ["field", "name", "first"],
+	    ["value", "David"]
+	  ],
+	  ["and",
+		["not",
+	      ["greaterthan",
+	        ["field", "age"],
+	        ["value", 50]
+	      ]
+	    ],
+	    ["equals",
+	      ["field", "isActive"],
+	      ["value", true]
+	    ]
+	  ]
+    ]`)
+
+	jsonExpr, err := ParseJsonExpression(matchJson)
+	assert.Nil(err)
+
+	var trans Transformer
+	matchDef := trans.Transform([]Expression{jsonExpr})
+	assert.NotNil(matchDef)
+
+	m := NewMatcher(matchDef)
+
+	userData := map[string]interface{}{
+		"name": map[string]interface{}{
+			"first": "Goliath",
+		},
+		"isActive": true,
+		"age":      50,
+	}
+	udMarsh, err := json.Marshal(userData)
+	if err != nil {
+	}
+	match, err := m.Match(udMarsh)
+	assert.Nil(err)
+	assert.True(match)
+
+	strExpr := "name.first == 'David' || (age <= 50 && isActive == true)"
 
 	ctx, err := NewExpressionParserCtx(strExpr)
 	assert.Nil(err)

--- a/simpleParser_test.go
+++ b/simpleParser_test.go
@@ -4,9 +4,8 @@ package gojsonsm
 
 import (
 	"encoding/json"
-	"testing"
-
 	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
 // Makes sure that the parsing of subcontext works
@@ -496,11 +495,9 @@ func TestParserExpressionOutput2a(t *testing.T) {
 
 	assert.Equal(jsonExpr.String(), simpleExpr.String())
 
-	// DEBUG Test
 	var trans Transformer
 	matchDef := trans.Transform([]Expression{simpleExpr})
 	m := NewMatcher(matchDef)
-	//	fmt.Printf("NEIL DEBUG matchDef tree: %v\n", matchDef.MatchTree.data)
 
 	userData := map[string]interface{}{
 		"name": map[string]interface{}{
@@ -515,6 +512,162 @@ func TestParserExpressionOutput2a(t *testing.T) {
 	match, err := m.Match(udMarsh)
 	assert.Nil(err)
 	assert.True(match)
+}
+
+func TestParserExpressionOutputNot(t *testing.T) {
+	assert := assert.New(t)
+
+	matchJson := []byte(`
+	["or",
+	  ["equals",
+	    ["field", "name", "first"],
+	    ["value", "Neal"]
+	  ],
+	  ["and",
+	    ["not",
+	      ["lessthan",
+	        ["field", "age"],
+	        ["value", 50]
+	      ]
+	    ],
+	    ["equals",
+	      ["field", "isActive"],
+	      ["value", true]
+	    ]
+	  ]
+    ]`)
+
+	jsonExpr, err := ParseJsonExpression(matchJson)
+	assert.Nil(err)
+
+	var trans Transformer
+	matchDef := trans.Transform([]Expression{jsonExpr})
+	assert.NotNil(matchDef)
+
+	m := NewMatcher(matchDef)
+	//	fmt.Printf("NEIL DEBUG matchDef tree: %v\n", matchDef.MatchTree.data)
+
+	userData := map[string]interface{}{
+		"name": map[string]interface{}{
+			"first": "Neil",
+		},
+		"isActive": false,
+		"age":      32,
+	}
+	udMarsh, err := json.Marshal(userData)
+	if err != nil {
+	}
+	match, err := m.Match(udMarsh)
+	assert.Nil(err)
+	assert.False(match)
+
+}
+
+func TestParserExpressionOutputNot2(t *testing.T) {
+	assert := assert.New(t)
+
+	matchJson := []byte(`
+	["or",
+	  ["equals",
+	    ["field", "name", "first"],
+	    ["value", "Neal"]
+	  ],
+	  ["and",
+	    ["not",
+	      ["lessthan",
+	        ["field", "age"],
+	        ["value", 50]
+	      ]
+	    ],
+	    ["equals",
+	      ["field", "isActive"],
+	      ["value", true]
+	    ]
+	  ]
+    ]`)
+
+	jsonExpr, err := ParseJsonExpression(matchJson)
+	assert.Nil(err)
+
+	var trans Transformer
+	matchDef := trans.Transform([]Expression{jsonExpr})
+	assert.NotNil(matchDef)
+
+	m := NewMatcher(matchDef)
+
+	userData := map[string]interface{}{
+		"name": map[string]interface{}{
+			"first": "Neil",
+		},
+		"isActive": true,
+		"age":      50,
+	}
+	udMarsh, err := json.Marshal(userData)
+	if err != nil {
+	}
+	match, err := m.Match(udMarsh)
+	assert.Nil(err)
+	assert.True(match)
+}
+
+func TestParserExpressionOutputNot3(t *testing.T) {
+	assert := assert.New(t)
+
+	matchJson := []byte(`
+	["or",
+	  ["equals",
+	    ["field", "name", "first"],
+	    ["value", "David"]
+	  ],
+	  ["and",
+	    ["lessthan",
+	      ["field", "age"],
+	      ["value", 50]
+	    ],
+	    ["not",
+	      ["equals",
+	        ["field", "isActive"],
+	        ["value", true]
+	      ]
+	    ]
+	  ]
+    ]`)
+
+	jsonExpr, err := ParseJsonExpression(matchJson)
+	assert.Nil(err)
+
+	var trans Transformer
+	matchDef := trans.Transform([]Expression{jsonExpr})
+	assert.NotNil(matchDef)
+
+	m := NewMatcher(matchDef)
+
+	userData := map[string]interface{}{
+		"name": map[string]interface{}{
+			"first": "Goliath",
+		},
+		"isActive": false,
+		"age":      49,
+	}
+	udMarsh, err := json.Marshal(userData)
+	if err != nil {
+	}
+	match, err := m.Match(udMarsh)
+	assert.Nil(err)
+	assert.False(match)
+
+	strExpr := "name.first == 'David' || (age < 50 && isActive != true)"
+
+	ctx, err := NewExpressionParserCtx(strExpr)
+	assert.Nil(err)
+
+	err = ctx.parse()
+	assert.Nil(err)
+
+	simpleExpr, err := ctx.outputExpression()
+	assert.Nil(err)
+
+	assert.Equal(jsonExpr.String(), simpleExpr.String())
 }
 
 // NEGATIVE test cases

--- a/simpleParser_test.go
+++ b/simpleParser_test.go
@@ -4,8 +4,9 @@ package gojsonsm
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // Makes sure that the parsing of subcontext works
@@ -831,4 +832,19 @@ func TestParserExpressionOutputNeg(t *testing.T) {
 
 	_, err = ctx.outputExpression()
 	assert.NotNil(err)
+}
+
+func TestParserExpressionWithGreaterThan(t *testing.T) {
+	assert := assert.New(t)
+
+	strExpr := "age > 50"
+
+	ctx, err := NewExpressionParserCtx(strExpr)
+	assert.Nil(err)
+
+	err = ctx.parse()
+	assert.Nil(err)
+
+	_, err = ctx.outputExpression()
+	assert.Nil(err)
 }

--- a/slowmatcher.go
+++ b/slowmatcher.go
@@ -9,14 +9,14 @@ import (
 )
 
 type SlowMatcher struct {
-	exprs []Expression
+	exprs       []Expression
 	exprMatches []bool
-	vars map[int]interface{}
+	vars        map[int]interface{}
 }
 
 func NewSlowMatcher(exprs []Expression) *SlowMatcher {
 	return &SlowMatcher{
-		exprs: exprs,
+		exprs:       exprs,
 		exprMatches: make([]bool, len(exprs)),
 	}
 }
@@ -193,13 +193,13 @@ func (m *SlowMatcher) matchLessThanExpr(expr LessThanExpr) (bool, error) {
 	return val < 0, nil
 }
 
-func (m *SlowMatcher) matchGreaterEqualExpr(expr GreaterEqualExpr) (bool, error) {
+func (m *SlowMatcher) matchGreaterThanExpr(expr GreaterThanExpr) (bool, error) {
 	val, err := m.compareExprs(expr.Lhs, expr.Rhs)
 	if err != nil {
 		return false, err
 	}
 
-	return val >= 0, nil
+	return val > 0, nil
 }
 
 func (m *SlowMatcher) matchOne(expr Expression) (bool, error) {
@@ -214,8 +214,8 @@ func (m *SlowMatcher) matchOne(expr Expression) (bool, error) {
 		return m.matchEqualsExpr(expr)
 	case LessThanExpr:
 		return m.matchLessThanExpr(expr)
-	case GreaterEqualExpr:
-		return m.matchGreaterEqualExpr(expr)
+	case GreaterThanExpr:
+		return m.matchGreaterThanExpr(expr)
 	}
 
 	panic("unexpected expression")

--- a/transform.go
+++ b/transform.go
@@ -65,7 +65,7 @@ type OpType int
 const (
 	OpTypeEquals OpType = iota
 	OpTypeLessThan
-	OpTypeGreaterEquals
+	OpTypeGreaterThan
 	OpTypeIn
 )
 
@@ -75,8 +75,8 @@ func opTypeToString(value OpType) string {
 		return "eq"
 	case OpTypeLessThan:
 		return "lt"
-	case OpTypeGreaterEquals:
-		return "gte"
+	case OpTypeGreaterThan:
+		return "gt"
 	case OpTypeIn:
 		return "in"
 	}
@@ -491,7 +491,7 @@ func (t *Transformer) transformLessThan(expr LessThanExpr) *ExecNode {
 	return nil
 }
 
-func (t *Transformer) transformGreaterEqual(expr GreaterEqualExpr) *ExecNode {
+func (t *Transformer) transformGreaterThan(expr GreaterThanExpr) *ExecNode {
 	if lhsField, ok := expr.Lhs.(FieldExpr); ok {
 		execNode := t.getExecNode(lhsField)
 
@@ -503,7 +503,7 @@ func (t *Transformer) transformGreaterEqual(expr GreaterEqualExpr) *ExecNode {
 
 		execNode.Ops = append(execNode.Ops, &OpNode{
 			t.ActiveBucketIdx,
-			OpTypeGreaterEquals,
+			OpTypeGreaterThan,
 			t.previousNotNode(),
 			t.makeRhsParam(expr.Rhs),
 		})
@@ -536,8 +536,8 @@ func (t *Transformer) transformOne(expr Expression) *ExecNode {
 		return t.transformEquals(expr)
 	case LessThanExpr:
 		return t.transformLessThan(expr)
-	case GreaterEqualExpr:
-		return t.transformGreaterEqual(expr)
+	case GreaterThanExpr:
+		return t.transformGreaterThan(expr)
 	}
 	return nil
 }


### PR DESCRIPTION
In order to get rid of my merge commits, I had to do a rebase and cherry-pick and with them, a few  conflicts.

- Found and fixed an issue where false JSON values were perceived as true.
- SimpleParser added a NOT operator, which is used in "!=", "<=", and ">=" operations. Utilizing Brett's code changes.
- Discussed with Brett about changing GreaterThanEq in matcher and associates to just Greater... since <= and >= can be accomplished with inverse of "<" and ">".
- Beefed up simpleParser unit test to test all the changes mentioned above. The scope of the simpleParser unit test should really be testing just the simpleParser, but it's slowly overstepping its boundary into matcher testing. Not a big deal for now but may address it later.

Note that this PR supersedes couchbaselabs/gojsonsm#13