### PR TITLE
Regex support

### DIFF
--- a/expression.go
+++ b/expression.go
@@ -317,3 +317,19 @@ func (expr GreaterEqualsExpr) RootRefs() []FieldExpr {
 	out = rootSetAdd(out, expr.Rhs.RootRefs()...)
 	return out
 }
+
+type MatchesExpr struct {
+	Lhs Expression
+	Rhs Expression
+}
+
+func (expr MatchesExpr) String() string {
+	return fmt.Sprintf("%s =~ %s", expr.Lhs, expr.Rhs)
+}
+
+func (expr MatchesExpr) RootRefs() []FieldExpr {
+	var out []FieldExpr
+	out = rootSetAdd(out, expr.Lhs.RootRefs()...)
+	out = rootSetAdd(out, expr.Rhs.RootRefs()...)
+	return out
+}

--- a/expression.go
+++ b/expression.go
@@ -81,6 +81,18 @@ func (expr ValueExpr) RootRefs() []FieldExpr {
 	return nil
 }
 
+type RegexExpr struct {
+	Regex interface{}
+}
+
+func (expr RegexExpr) String() string {
+	return fmt.Sprintf("/%v/", expr.Regex)
+}
+
+func (expr RegexExpr) RootRefs() []FieldExpr {
+	return nil
+}
+
 type NotExpr struct {
 	SubExpr Expression
 }
@@ -318,16 +330,16 @@ func (expr GreaterEqualsExpr) RootRefs() []FieldExpr {
 	return out
 }
 
-type MatchesExpr struct {
+type LikeExpr struct {
 	Lhs Expression
 	Rhs Expression
 }
 
-func (expr MatchesExpr) String() string {
+func (expr LikeExpr) String() string {
 	return fmt.Sprintf("%s =~ %s", expr.Lhs, expr.Rhs)
 }
 
-func (expr MatchesExpr) RootRefs() []FieldExpr {
+func (expr LikeExpr) RootRefs() []FieldExpr {
 	var out []FieldExpr
 	out = rootSetAdd(out, expr.Lhs.RootRefs()...)
 	out = rootSetAdd(out, expr.Rhs.RootRefs()...)

--- a/expression_json.go
+++ b/expression_json.go
@@ -219,6 +219,15 @@ func parseJsonAnyEveryIn(data []interface{}) (Expression, error) {
 	return AnyEveryInExpr{varID, lhsExpr, subexprExpr}, nil
 }
 
+func parseJsonMatches(data []interface{}) (Expression, error) {
+	lhs, rhs, err := parseJsonComparison(data)
+	if err != nil {
+		return nil, err
+	}
+
+	return MatchesExpr{lhs, rhs}, nil
+}
+
 func parseJsonSubexpr(data []interface{}) (Expression, error) {
 	exprType, ok := data[0].(string)
 	if !ok {
@@ -255,6 +264,8 @@ func parseJsonSubexpr(data []interface{}) (Expression, error) {
 		return parseJsonGreaterThan(data)
 	case "greaterequals":
 		return parseJsonGreaterEquals(data)
+	case "matches":
+		return parseJsonMatches(data)
 	}
 
 	return nil, errors.New("invalid expression type")

--- a/expression_json.go
+++ b/expression_json.go
@@ -219,13 +219,19 @@ func parseJsonAnyEveryIn(data []interface{}) (Expression, error) {
 	return AnyEveryInExpr{varID, lhsExpr, subexprExpr}, nil
 }
 
-func parseJsonMatches(data []interface{}) (Expression, error) {
+func parseJsonLike(data []interface{}) (Expression, error) {
 	lhs, rhs, err := parseJsonComparison(data)
 	if err != nil {
 		return nil, err
 	}
 
-	return MatchesExpr{lhs, rhs}, nil
+	return LikeExpr{lhs, rhs}, nil
+}
+
+func parseJsonRegex(data []interface{}) (Expression, error) {
+	return RegexExpr{
+		data[1],
+	}, nil
 }
 
 func parseJsonSubexpr(data []interface{}) (Expression, error) {
@@ -264,8 +270,10 @@ func parseJsonSubexpr(data []interface{}) (Expression, error) {
 		return parseJsonGreaterThan(data)
 	case "greaterequals":
 		return parseJsonGreaterEquals(data)
-	case "matches":
-		return parseJsonMatches(data)
+	case "like":
+		return parseJsonLike(data)
+	case "regex":
+		return parseJsonRegex(data)
 	}
 
 	return nil, errors.New("invalid expression type")

--- a/matcher.go
+++ b/matcher.go
@@ -125,8 +125,6 @@ func (m *Matcher) matchExec(token tokenType, tokenData []byte, node *ExecNode) e
 
 				var opRes bool
 				switch op.Op {
-				case OpTypeMatches:
-					fallthrough
 				case OpTypeEquals:
 					opRes = litVal.Equals(opVal)
 				case OpTypeNotEquals:
@@ -139,6 +137,8 @@ func (m *Matcher) matchExec(token tokenType, tokenData []byte, node *ExecNode) e
 					opRes = litVal.Compare(opVal) > 0
 				case OpTypeGreaterEquals:
 					opRes = litVal.Compare(opVal) >= 0
+				case OpTypeMatches:
+					opRes = litVal.Matches(opVal)
 				default:
 					panic("invalid op type")
 				}

--- a/matcher.go
+++ b/matcher.go
@@ -125,6 +125,8 @@ func (m *Matcher) matchExec(token tokenType, tokenData []byte, node *ExecNode) e
 
 				var opRes bool
 				switch op.Op {
+				case OpTypeMatches:
+					fallthrough
 				case OpTypeEquals:
 					opRes = litVal.Equals(opVal)
 				case OpTypeNotEquals:

--- a/simpleParser.go
+++ b/simpleParser.go
@@ -11,7 +11,7 @@ import (
 /**
  * SimpleParser provides user to be able to specify a C-Styled expression for gojsonsm.
  *
- * Values can be string or floats. Strings should be enclosed by single quotes, as to not be confused
+ * Values can be string or floats. Strings should be enclosed by double quotes, as to not be confused
  * with field variables
  *
  * Parenthesis are allowed, but must be surrounded by at least 1 white space
@@ -19,7 +19,7 @@ import (
  * 		==/=, !=, ||/OR, &&/AND, >=, >, <=, <
  *
  * Usage example:
- * exprStr := "name.first == 'Neil' && (age < 50 || isActive == true)"
+ * exprStr := "name.first == "Neil" && (age < 50 || isActive == true)"
  * expr, err := ParseSimpleExpression(exprStr)
  *
  * Notes:
@@ -36,7 +36,7 @@ var ErrorParenWSpace error = fmt.Errorf("Error: parenthesis must have white spac
 var NonErrorOneLayerDone error = fmt.Errorf("One layer has finished")
 
 // Values by def should be enclosed within single quotes
-var valueRegex *regexp.Regexp = regexp.MustCompile(`^\'.*\'$`)
+var valueRegex *regexp.Regexp = regexp.MustCompile(`^\".*\"$`)
 
 // Or Values can be int or floats by themselves (w/o alpha char)
 var valueNumRegex *regexp.Regexp = regexp.MustCompile(`^(-?)(0|([1-9][0-9]*))(\\.[0-9]+)?$`)
@@ -457,7 +457,7 @@ func (ctx *expressionParserContext) getCurrentToken() (string, ParseTokenType, e
 		return token, TokenTypeOperator, nil
 	} else if valueRegex.MatchString(token) {
 		// For value, strip the single quote
-		token = strings.Trim(token, "'")
+		token = strings.Trim(token, "\"")
 		return token, TokenTypeValue, nil
 	} else if valueNumRegex.MatchString(token) {
 		return token, TokenTypeValue, nil

--- a/simpleParser_test.go
+++ b/simpleParser_test.go
@@ -12,7 +12,7 @@ import (
 func TestSimpleParserSubContext1(t *testing.T) {
 	assert := assert.New(t)
 
-	testString := "true || name.first == 'Neil'"
+	testString := "true || name.first == \"Neil\""
 	ctx, err := NewExpressionParserCtx(testString)
 	assert.Equal(fieldMode, ctx.subCtx.currentMode)
 	err = ctx.parse()
@@ -34,7 +34,7 @@ func TestSimpleParserSubContext1(t *testing.T) {
 func TestSimpleParserSubContext2(t *testing.T) {
 	assert := assert.New(t)
 
-	testString := "true && name.first == 'Neil' || age < 50"
+	testString := "true && name.first == \"Neil\" || age < 50"
 	ctx, err := NewExpressionParserCtx(testString)
 	assert.Equal(fieldMode, ctx.subCtx.currentMode)
 	err = ctx.parse()
@@ -60,7 +60,7 @@ func TestSimpleParserSubContext2(t *testing.T) {
 func TestSimpleParserSubContext2a(t *testing.T) {
 	assert := assert.New(t)
 
-	testString := "(true && name.first == 'Neil') || age < 50"
+	testString := "(true && name.first == \"Neil\") || age < 50"
 	ctx, err := NewExpressionParserCtx(testString)
 	assert.Equal(fieldMode, ctx.subCtx.currentMode)
 	err = ctx.parse()
@@ -85,7 +85,7 @@ func TestSimpleParserSubContext2a(t *testing.T) {
 func TestSimpleParserSubContext3(t *testing.T) {
 	assert := assert.New(t)
 
-	testString := "name.first == 'Neil' && age < 50"
+	testString := "name.first == \"Neil\" && age < 50"
 	ctx, err := NewExpressionParserCtx(testString)
 	assert.Equal(fieldMode, ctx.subCtx.currentMode)
 	err = ctx.parse()
@@ -108,7 +108,7 @@ func TestSimpleParserSubContext3(t *testing.T) {
 func TestSimpleParserSubContext4(t *testing.T) {
 	assert := assert.New(t)
 
-	testString := "name.first == 'Neil' && age < 50 || isActive == true"
+	testString := "name.first == \"Neil\" && age < 50 || isActive == true"
 	ctx, err := NewExpressionParserCtx(testString)
 	assert.Equal(fieldMode, ctx.subCtx.currentMode)
 	err = ctx.parse()
@@ -138,7 +138,7 @@ func TestSimpleParserSubContext4a(t *testing.T) {
 	assert := assert.New(t)
 
 	// This should have short circuiting -> name.first should be checked first
-	testString := "name.first == 'Neil' && age < 50 && isActive == true"
+	testString := "name.first == \"Neil\" && age < 50 && isActive == true"
 	ctx, err := NewExpressionParserCtx(testString)
 	assert.Equal(fieldMode, ctx.subCtx.currentMode)
 	ctx.enableShortCircuitEvalIfPossible() // NOTE this call - usually wrapped in main func
@@ -169,7 +169,7 @@ func TestSimpleParserSubContext4b(t *testing.T) {
 	assert := assert.New(t)
 
 	// Same as 4a but no short circuit eval
-	testString := "name.first == 'Neil' && age < 50 && isActive == true"
+	testString := "name.first == \"Neil\" && age < 50 && isActive == true"
 	ctx, err := NewExpressionParserCtx(testString)
 	assert.Equal(fieldMode, ctx.subCtx.currentMode)
 	err = ctx.parse()
@@ -198,7 +198,7 @@ func TestSimpleParserSubContext4b(t *testing.T) {
 func TestSimpleParserSubContext5(t *testing.T) {
 	assert := assert.New(t)
 
-	testString := "((name.first == 'Neil'))"
+	testString := "((name.first == \"Neil\"))"
 	ctx, err := NewExpressionParserCtx(testString)
 	assert.Equal(fieldMode, ctx.subCtx.currentMode)
 	err = ctx.parse()
@@ -215,7 +215,7 @@ func TestSimpleParserSubContext5(t *testing.T) {
 func TestSimpleParserSubContext5a(t *testing.T) {
 	assert := assert.New(t)
 
-	testString := "( name.first == 'Neil')"
+	testString := "( name.first == \"Neil\")"
 	ctx, err := NewExpressionParserCtx(testString)
 	assert.Equal(fieldMode, ctx.subCtx.currentMode)
 	err = ctx.parse()
@@ -232,7 +232,7 @@ func TestSimpleParserSubContext5a(t *testing.T) {
 func TestSimpleParserSubContext6(t *testing.T) {
 	assert := assert.New(t)
 
-	testString := "name.first == 'Neil' && (age < 50 || isActive == true)"
+	testString := "name.first == \"Neil\" && (age < 50 || isActive == true)"
 	ctx, err := NewExpressionParserCtx(testString)
 	assert.Equal(fieldMode, ctx.subCtx.currentMode)
 	err = ctx.parse()
@@ -261,7 +261,7 @@ func TestSimpleParserSubContext6(t *testing.T) {
 func TestSimpleParserSubContext7(t *testing.T) {
 	assert := assert.New(t)
 
-	testString := "(name.first == 'Neil') && (age < 50 || isActive == true)"
+	testString := "(name.first == \"Neil\") && (age < 50 || isActive == true)"
 	ctx, err := NewExpressionParserCtx(testString)
 	assert.Equal(fieldMode, ctx.subCtx.currentMode)
 	err = ctx.parse()
@@ -290,7 +290,7 @@ func TestSimpleParserSubContext7(t *testing.T) {
 func TestSimpleParserSubContext7a(t *testing.T) {
 	assert := assert.New(t)
 
-	testString := "(name.first == 'Neil' )&& (age < 50 || isActive == true)"
+	testString := "(name.first == \"Neil\" )&& (age < 50 || isActive == true)"
 	ctx, err := NewExpressionParserCtx(testString)
 	assert.Equal(fieldMode, ctx.subCtx.currentMode)
 	err = ctx.parse()
@@ -318,7 +318,7 @@ func TestSimpleParserSubContext7a(t *testing.T) {
 
 func TestContextShortCircuit1(t *testing.T) {
 	assert := assert.New(t)
-	testString := "name.first == 'Neil' || (age < 50) || (true)"
+	testString := "name.first == \"Neil\" || (age < 50) || (true)"
 	ctx, _ := NewExpressionParserCtx(testString)
 
 	ctx.enableShortCircuitEvalIfPossible()
@@ -327,7 +327,7 @@ func TestContextShortCircuit1(t *testing.T) {
 
 func TestContextShortCircuit2(t *testing.T) {
 	assert := assert.New(t)
-	testString := "name.first == 'Neil' || (age < 50) && (true)"
+	testString := "name.first == \"Neil\" || (age < 50) && (true)"
 	ctx, _ := NewExpressionParserCtx(testString)
 
 	ctx.enableShortCircuitEvalIfPossible()
@@ -336,7 +336,7 @@ func TestContextShortCircuit2(t *testing.T) {
 
 func TestContextParserMultiwordToken(t *testing.T) {
 	assert := assert.New(t)
-	testString := "name.first NOT MATCH 'abc'"
+	testString := "name.first NOT MATCH \"abc\""
 	ctx, err := NewExpressionParserCtx(testString)
 
 	// name.first
@@ -379,7 +379,7 @@ func TestContextParserMultiwordToken2(t *testing.T) {
 
 func TestContextParserToken(t *testing.T) {
 	assert := assert.New(t)
-	testString := "name.first == 'Neil' || (age < 50) || (true)"
+	testString := "name.first == \"Neil\" || (age < 50) || (true)"
 	ctx, err := NewExpressionParserCtx(testString)
 
 	// name.first
@@ -394,7 +394,7 @@ func TestContextParserToken(t *testing.T) {
 	assert.Nil(err)
 	ctx.advanceToken()
 
-	// 'Neil'
+	// "Neil"
 	_, tokenType, err = ctx.getCurrentToken()
 	assert.Equal(tokenType, (ParseTokenType)(TokenTypeValue))
 	assert.Nil(err)
@@ -524,7 +524,7 @@ func TestParserExpressionOutput2a(t *testing.T) {
 	jsonExpr, err := ParseJsonExpression(matchJson)
 	assert.Nil(err)
 
-	strExpr := "name.first == 'Neil' || (age < 50 && isActive == true)"
+	strExpr := "name.first == \"Neil\" || (age < 50 && isActive == true)"
 
 	ctx, err := NewExpressionParserCtx(strExpr)
 	assert.Nil(err)
@@ -695,7 +695,7 @@ func TestParserExpressionOutputNot3(t *testing.T) {
 	assert.Nil(err)
 	assert.True(match)
 
-	strExpr := "name.first == 'David' || (age < 50 && isActive != true)"
+	strExpr := "name.first == \"David\" || (age < 50 && isActive != true)"
 
 	ctx, err := NewExpressionParserCtx(strExpr)
 	assert.Nil(err)
@@ -753,7 +753,7 @@ func TestParserExpressionOutputGreaterThan(t *testing.T) {
 	assert.Nil(err)
 	assert.True(match)
 
-	strExpr := "name.first == 'David' || (age > 50 && isActive == true)"
+	strExpr := "name.first == \"David\" || (age > 50 && isActive == true)"
 
 	ctx, err := NewExpressionParserCtx(strExpr)
 	assert.Nil(err)
@@ -811,7 +811,7 @@ func TestParserExpressionOutputGreaterThanEquals(t *testing.T) {
 	assert.Nil(err)
 	assert.True(match)
 
-	strExpr := "name.first == 'David' || (age >= 50 && isActive == true)"
+	strExpr := "name.first == \"David\" || (age >= 50 && isActive == true)"
 
 	ctx, err := NewExpressionParserCtx(strExpr)
 	assert.Nil(err)
@@ -869,7 +869,7 @@ func TestParserExpressionOutputLessThan(t *testing.T) {
 	assert.Nil(err)
 	assert.True(match)
 
-	strExpr := "name.first == 'David' || (age < 50 && isActive == true)"
+	strExpr := "name.first == \"David\" || (age < 50 && isActive == true)"
 
 	ctx, err := NewExpressionParserCtx(strExpr)
 	assert.Nil(err)
@@ -927,7 +927,7 @@ func TestParserExpressionOutputLessThanEq(t *testing.T) {
 	assert.Nil(err)
 	assert.True(match)
 
-	strExpr := "name.first == 'David' || (age <= 50 && isActive == true)"
+	strExpr := "name.first == \"David\" || (age <= 50 && isActive == true)"
 
 	ctx, err := NewExpressionParserCtx(strExpr)
 	assert.Nil(err)
@@ -943,8 +943,8 @@ func TestParserExpressionOutputLessThanEq(t *testing.T) {
 
 func TestParserAlternativeOperators(t *testing.T) {
 	assert := assert.New(t)
-	strExpr := "name.first == 'David' || (age < 50 && isActive != true)"
-	strExpr2 := "name.first = 'David' OR (age < 50 AND isActive != true)"
+	strExpr := "name.first == \"David\" || (age < 50 && isActive != true)"
+	strExpr2 := "name.first = \"David\" OR (age < 50 AND isActive != true)"
 
 	ctx, err := NewExpressionParserCtx(strExpr)
 	assert.Nil(err)
@@ -968,7 +968,7 @@ func TestParserAlternativeOperators(t *testing.T) {
 func TestSimpleParserParenMismatch(t *testing.T) {
 	assert := assert.New(t)
 
-	testString := "(name.first == 'Neil'))"
+	testString := "(name.first == \"Neil\"))"
 	ctx, err := NewExpressionParserCtx(testString)
 	assert.Equal(fieldMode, ctx.subCtx.currentMode)
 	err = ctx.parse()
@@ -978,7 +978,7 @@ func TestSimpleParserParenMismatch(t *testing.T) {
 func TestSimpleParserParenMismatch2(t *testing.T) {
 	assert := assert.New(t)
 
-	testString := "((name.first == 'Neil')"
+	testString := "((name.first == \"Neil\")"
 	ctx, err := NewExpressionParserCtx(testString)
 	assert.Equal(fieldMode, ctx.subCtx.currentMode)
 	err = ctx.parse()
@@ -1069,7 +1069,7 @@ func TestSimpleParserNeg5(t *testing.T) {
 func TestSimpleParserNeg6(t *testing.T) {
 	assert := assert.New(t)
 
-	testString := "'Neil' == name.first && 50 > age"
+	testString := "\"Neil\" == name.first && 50 > age"
 	ctx, err := NewExpressionParserCtx(testString)
 	assert.Equal(fieldMode, ctx.subCtx.currentMode)
 	err = ctx.parse()
@@ -1144,7 +1144,7 @@ func TestParserExpressionWithGreaterThan(t *testing.T) {
 
 func TestContextParserNegMultiwordToken(t *testing.T) {
 	assert := assert.New(t)
-	testString := "name.first IS NOT MATCH 'abc'"
+	testString := "name.first IS NOT MATCH \"abc\""
 	ctx, err := NewExpressionParserCtx(testString)
 
 	// name.first


### PR DESCRIPTION
Related to https://github.com/couchbaselabs/gojsonsm/issues/19

- SimpleParser regex parsing support
- Some minor SimpleParser syntax changes
- JsonParser for regex (matches) operation.
- New regex FastVal
- Matcher and Transformer changes to allow Regex FastVal comparisons