### PR TITLE
Fixes #24: Adds array indexing support

### DIFF
--- a/simpleParser.go
+++ b/simpleParser.go
@@ -651,10 +651,10 @@ func checkAndParseField(token string, subTokens *[]string) error {
 			case fieldSeparator:
 				if !skipAppend {
 					*subTokens = append(*subTokens, string(token[beginPos:pos]))
-					beginPos = pos + 1
 				} else {
 					skipAppend = false
 				}
+				beginPos = pos + 1
 			case fieldLiteral:
 				mode = cfmBacktick
 				beginPos = pos + 1
@@ -707,8 +707,10 @@ func checkAndParseField(token string, subTokens *[]string) error {
 				if pos == len(token)-1 || (pos < len(token)-1 && string(token[pos+1]) == fieldNestedStart) {
 					skipAppend = true
 				}
-				// For now, bracket can be used only for array indexing
+			case fieldSeparator:
+				fallthrough
 			case fieldLiteral:
+				// For now, bracket can be used only for array indexing
 				return ErrorAllInts
 			}
 		}

--- a/simpleParser_test.go
+++ b/simpleParser_test.go
@@ -1298,6 +1298,50 @@ func TestParserExpressionOutputExists(t *testing.T) {
 			"first": "Neil",
 		},
 	}
+
+	udMarsh, _ := json.Marshal(userData)
+	match, err := m.Match(udMarsh)
+	assert.Nil(err)
+	assert.True(match)
+
+}
+
+func TestParserExpressionOutputArrayEquals(t *testing.T) {
+	assert := assert.New(t)
+
+	matchJson := []byte(`
+	["equals",
+		["field", "userIDs", "[1]"],
+		["value", "nelio2k"]
+	]`)
+
+	jsonExpr, err := ParseJsonExpression(matchJson)
+	assert.Nil(err)
+	strExpr := "userIDs[1] == \"nelio2k\""
+
+	ctx, err := NewExpressionParserCtx(strExpr)
+	assert.Nil(err)
+
+	err = ctx.parse()
+	assert.Nil(err)
+
+	simpleExpr, err := ctx.outputExpression()
+	assert.Nil(err)
+
+	var trans Transformer
+	matchDef := trans.Transform([]Expression{simpleExpr})
+	assert.NotNil(matchDef)
+
+	assert.Equal(jsonExpr.String(), simpleExpr.String())
+
+	m := NewMatcher(matchDef)
+	userData := map[string]interface{}{
+		"userIDs": []string{
+			"brett19",
+			"nelio2k",
+		},
+	}
+
 	udMarsh, _ := json.Marshal(userData)
 	match, err := m.Match(udMarsh)
 	assert.Nil(err)
@@ -1735,4 +1779,45 @@ func TestContextParserNegMultiwordToken(t *testing.T) {
 	_, tokenType, err = ctx.getCurrentToken()
 	assert.NotNil(err)
 	ctx.advanceToken()
+}
+
+func TestParserExpressionOutputArrayEqualsMissing(t *testing.T) {
+	assert := assert.New(t)
+
+	matchJson := []byte(`
+	["equals",
+		["field", "userIDs", "[1]"],
+		["value", "nelio2k"]
+	]`)
+
+	jsonExpr, err := ParseJsonExpression(matchJson)
+	assert.Nil(err)
+	strExpr := "userIDs[1] == \"nelio2k\""
+
+	ctx, err := NewExpressionParserCtx(strExpr)
+	assert.Nil(err)
+
+	err = ctx.parse()
+	assert.Nil(err)
+
+	simpleExpr, err := ctx.outputExpression()
+	assert.Nil(err)
+
+	var trans Transformer
+	matchDef := trans.Transform([]Expression{simpleExpr})
+	assert.NotNil(matchDef)
+
+	assert.Equal(jsonExpr.String(), simpleExpr.String())
+
+	m := NewMatcher(matchDef)
+	userData := map[string]interface{}{
+		"userIDsAlternate": []string{
+			"brett19",
+			"nelio2k",
+		},
+	}
+	udMarsh, _ := json.Marshal(userData)
+	match, err := m.Match(udMarsh)
+	assert.Nil(err)
+	assert.False(match)
 }


### PR DESCRIPTION
The array support changeset is made on top of the expression fix for #30 because the fix for #30 allows array to be outputted correctly from the simpleParser. I've included the commit here so that unit tests will pass with both commits. Otherwise, with just the commit for array support, unit tests would fail.

The actual change to array support is relatively simple, by piggy-backing off the object parsing and refactoring a bit so the same logic can work for both situations.