### PR TITLE
Fixes #51: Add pcre support to allow lookahead/lookbehind matching

### DIFF
--- a/expression.go
+++ b/expression.go
@@ -51,6 +51,14 @@ func (expr RegexExpr) String() string {
 	return fmt.Sprintf("/%v/", expr.Regex)
 }
 
+type PcreExpr struct {
+	Pcre interface{}
+}
+
+func (expr PcreExpr) String() string {
+	return fmt.Sprintf("/%v/", expr.Pcre)
+}
+
 type NotExpr struct {
 	SubExpr Expression
 }

--- a/expression_utils.go
+++ b/expression_utils.go
@@ -45,6 +45,7 @@ func fetchExprFieldRefsRecurse(expr Expression, loopVars []VariableID, fields []
 		fields = append(fields, expr)
 	case ValueExpr:
 	case RegexExpr:
+	case PcreExpr:
 	case FuncExpr:
 		for _, subexpr := range expr.Params {
 			fields = fetchExprFieldRefsRecurse(subexpr, loopVars, fields)

--- a/fastval.go
+++ b/fastval.go
@@ -28,6 +28,7 @@ const (
 	BinStringValue
 	JsonStringValue
 	RegexValue
+	PcreValue
 	BinaryValue
 	NullValue
 	TrueValue
@@ -232,10 +233,12 @@ func (val FastVal) AsBoolean() bool {
 	return val.AsInt() != 0
 }
 
-func (val FastVal) AsRegex() *regexp.Regexp {
+func (val FastVal) AsRegex() FastValRegexIface {
 	switch val.dataType {
 	case RegexValue:
 		return val.data.(*regexp.Regexp)
+	case PcreValue:
+		return val.data.(PcreWrapperInterface)
 	}
 	return nil
 }
@@ -419,6 +422,8 @@ func NewFastVal(val interface{}) FastVal {
 		return NewBinaryFastVal(val)
 	case *regexp.Regexp:
 		return NewRegexpFastVal(val)
+	case PcreWrapperInterface:
+		return NewPcreFastVal(val)
 	case nil:
 		return NewNullFastVal()
 	}
@@ -537,4 +542,16 @@ func NewRegexpFastVal(value *regexp.Regexp) FastVal {
 		data:     value,
 	}
 	return val
+}
+
+func NewPcreFastVal(value PcreWrapperInterface) FastVal {
+	val := FastVal{
+		dataType: PcreValue,
+		data:     value,
+	}
+	return val
+}
+
+type FastValRegexIface interface {
+	Match(b []byte) bool
 }

--- a/pcre_wrapper.go
+++ b/pcre_wrapper.go
@@ -1,0 +1,32 @@
+// Copyright 2018 Couchbase, Inc. All rights reserved.
+
+// +build pcre
+
+package gojsonsm
+
+import (
+	"errors"
+	"github.com/glenn-brown/golang-pkg-pcre/src/pkg/pcre"
+)
+
+type PcreWrapper struct {
+	pcreRegex *pcre.Regexp
+}
+
+func MakePcreWrapper(expression string) (PcreWrapperInterface, error) {
+	pcreWrapper := &PcreWrapper{}
+
+	pcreRegex, err := pcre.Compile(expression, 0)
+	if err != nil {
+		return pcreWrapper, errors.New("failed to compile PcreExpr: " + err.Message)
+	}
+	pcreWrapper.pcreRegex = &pcreRegex
+
+	return pcreWrapper, nil
+}
+
+func (wrapper *PcreWrapper) Match(b []byte) bool {
+	matcher := pcre.Matcher{}
+	matcher.Reset(*wrapper.pcreRegex, b, 0)
+	return matcher.Matches()
+}

--- a/pcre_wrapper_disabled.go
+++ b/pcre_wrapper_disabled.go
@@ -1,0 +1,16 @@
+// Copyright 2018 Couchbase, Inc. All rights reserved.
+
+// +build !pcre
+
+package gojsonsm
+
+type PcreWrapper struct {
+}
+
+func MakePcreWrapper(expression string) (PcreWrapperInterface, error) {
+	return &PcreWrapper{}, ErrorPcreNotSupported
+}
+
+func (wrapper *PcreWrapper) Match(b []byte) bool {
+	return false
+}

--- a/pcre_wrapper_interface.go
+++ b/pcre_wrapper_interface.go
@@ -1,0 +1,7 @@
+// Copyright 2018 Couchbase, Inc. All rights reserved.
+
+package gojsonsm
+
+type PcreWrapperInterface interface {
+	Match(b []byte) bool
+}

--- a/simpleParserPcre_test.go
+++ b/simpleParserPcre_test.go
@@ -1,0 +1,192 @@
+// Copyright 2018 Couchbase, Inc. All rights reserved.
+
+// +build pcre
+
+package gojsonsm
+
+import (
+	"encoding/json"
+	"github.com/glenn-brown/golang-pkg-pcre/src/pkg/pcre"
+	"github.com/stretchr/testify/assert"
+	"regexp"
+	"testing"
+)
+
+func TestPcre(t *testing.T) {
+	assert := assert.New(t)
+
+	testString := "afoobar"
+	testPattern := "a(?=foo)"
+
+	pregex := pcre.MustCompile(testPattern, 0)
+	assert.NotNil(pregex)
+
+	pcreMatcher := &pcre.Matcher{}
+	pcreMatcher.ResetString(pregex, testString, 0)
+	assert.True(pcreMatcher.Matches())
+
+	//	lookAheadPattern := "(?=foo)"
+	lookAheadPattern := "\\(\\?\\=.+\\)"
+	lap := regexp.MustCompile(lookAheadPattern)
+	assert.NotNil(lap)
+	assert.True(lap.MatchString(testPattern))
+	lookBehindPattern := "\\(\\?\\<.+\\)"
+	lbp := regexp.MustCompile(lookBehindPattern)
+	assert.NotNil(lbp)
+	assert.True(lbp.MatchString("a(?<foo)"))
+	negLookAheadPattern := "\\(\\?\\!.+\\)"
+	nlap := regexp.MustCompile(negLookAheadPattern)
+	assert.NotNil(nlap)
+	assert.True(nlap.MatchString("a(?!foo)"))
+	negLookBehindPattern := "\\(\\?\\<\\!.+\\)"
+	nlbp := regexp.MustCompile(negLookBehindPattern)
+	assert.NotNil(nlbp)
+	assert.True(nlbp.MatchString("a(?<!foo)"))
+}
+
+func TestContextParserPcreToken(t *testing.T) {
+	assert := assert.New(t)
+	testString := "name.first == \"Neil\" || (age < 50) || (true) && `someStr` LIKE \"a(?<!foo)\""
+	ctx, err := NewExpressionParserCtx(testString)
+
+	// name.first
+	_, tokenType, err := ctx.getCurrentToken()
+	assert.Equal(tokenType, (ParseTokenType)(TokenTypeField))
+	assert.Nil(err)
+	assert.Equal(2, len(ctx.lastFieldTokens))
+	assert.Equal(ctx.lastFieldTokens[0], "name")
+	assert.Equal(ctx.lastFieldTokens[1], "first")
+	ctx.advanceToken()
+
+	// ==
+	_, tokenType, err = ctx.getCurrentToken()
+	assert.Equal(tokenType, (ParseTokenType)(TokenTypeOperator))
+	assert.Nil(err)
+	ctx.advanceToken()
+
+	// "Neil"
+	_, tokenType, err = ctx.getCurrentToken()
+	assert.Equal(tokenType, (ParseTokenType)(TokenTypeValue))
+	assert.Nil(err)
+	ctx.advanceToken()
+
+	// ||
+	_, tokenType, err = ctx.getCurrentToken()
+	assert.Equal(tokenType, (ParseTokenType)(TokenTypeOperator))
+	assert.Nil(err)
+	ctx.advanceToken()
+
+	// (`age` -- will trim and will auto advance
+	_, tokenType, err = ctx.getCurrentToken()
+	assert.Equal(tokenType, (ParseTokenType)(TokenTypeParen))
+	assert.Nil(err)
+
+	// `age`
+	_, tokenType, err = ctx.getCurrentToken()
+	assert.Equal(tokenType, (ParseTokenType)(TokenTypeField))
+	assert.Nil(err)
+	//	fmt.Printf("`age` token: %v\n", token)
+	ctx.advanceToken()
+
+	// <
+	_, tokenType, err = ctx.getCurrentToken()
+	assert.Equal(tokenType, (ParseTokenType)(TokenTypeOperator))
+	assert.Nil(err)
+	ctx.advanceToken()
+
+	// 50)
+	_, tokenType, err = ctx.getCurrentToken()
+	assert.Equal(tokenType, (ParseTokenType)(TokenTypeValue))
+	assert.Nil(err)
+	ctx.advanceToken()
+
+	// )
+	_, tokenType, err = ctx.getCurrentToken()
+	assert.Equal(tokenType, (ParseTokenType)(TokenTypeEndParen))
+	assert.Nil(err)
+	ctx.advanceToken()
+
+	// ||
+	_, tokenType, err = ctx.getCurrentToken()
+	assert.Equal(tokenType, (ParseTokenType)(TokenTypeOperator))
+	assert.Nil(err)
+	ctx.advanceToken()
+
+	// (true -- will trim and auto advance
+	_, tokenType, err = ctx.getCurrentToken()
+	assert.Equal(tokenType, (ParseTokenType)(TokenTypeParen))
+	assert.Nil(err)
+
+	// true
+	_, tokenType, err = ctx.getCurrentToken()
+	assert.Equal(tokenType, (ParseTokenType)(TokenTypeTrue))
+	assert.Nil(err)
+	ctx.advanceToken()
+
+	// )
+	_, tokenType, err = ctx.getCurrentToken()
+	assert.Equal(tokenType, (ParseTokenType)(TokenTypeEndParen))
+	assert.Nil(err)
+	ctx.advanceToken()
+
+	// ||
+	_, tokenType, err = ctx.getCurrentToken()
+	assert.Equal(tokenType, (ParseTokenType)(TokenTypeOperator))
+	assert.Nil(err)
+	ctx.advanceToken()
+
+	// SomeStr
+	_, tokenType, err = ctx.getCurrentToken()
+	assert.Equal(tokenType, (ParseTokenType)(TokenTypeField))
+	assert.Nil(err)
+	ctx.advanceToken()
+
+	// LIKE
+	_, tokenType, err = ctx.getCurrentToken()
+	assert.Equal(tokenType, (ParseTokenType)(TokenTypeOperator))
+	assert.Nil(err)
+	ctx.advanceToken()
+
+	// a(?<!foo)\
+	_, tokenType, err = ctx.getCurrentToken()
+	assert.Equal(tokenType, (ParseTokenType)(TokenTypePcre))
+	assert.Nil(err)
+	ctx.advanceToken()
+}
+
+func TestParserExpressionPcre(t *testing.T) {
+	assert := assert.New(t)
+
+	strExpr := "pcreKey LIKE \"q(?!uit)\""
+
+	ctx, err := NewExpressionParserCtx(strExpr)
+	assert.Nil(err)
+
+	err = ctx.parse()
+	assert.Nil(err)
+
+	simpleExpr, err := ctx.outputExpression()
+	assert.Nil(err)
+
+	var trans Transformer
+	matchDef := trans.Transform([]Expression{simpleExpr})
+	assert.NotNil(matchDef)
+
+	m := NewMatcher(matchDef)
+	userData := map[string]interface{}{
+		"pcreKey": "quino",
+	}
+	udMarsh, _ := json.Marshal(userData)
+	match, err := m.Match(udMarsh)
+	assert.Nil(err)
+	assert.True(match)
+
+	m2 := NewMatcher(matchDef)
+	userDataFalse := map[string]interface{}{
+		"pcreKey": "quit",
+	}
+	udMarsh, _ = json.Marshal(userDataFalse)
+	match, err = m2.Match(udMarsh)
+	assert.Nil(err)
+	assert.False(match)
+}

--- a/transform.go
+++ b/transform.go
@@ -306,6 +306,9 @@ func (t *Transformer) makeDataRefRecurse(expr Expression, context nodeRef, isRoo
 			return nil, errors.New("failed to compile RegexExpr: " + err.Error())
 		}
 		return NewFastVal(regex), nil
+	case PcreExpr:
+		pcreWrapper, err := MakePcreWrapper(expr.Pcre.(string))
+		return NewFastVal(pcreWrapper), err
 	case FuncExpr:
 		var params []DataRef
 


### PR DESCRIPTION
This PR will add pcre support to gojsonsm. The library being used is a GitHub pull-able port of https://godoc.org/github.com/glenn-brown/golang-pkg-pcre/src/pkg/pcre

This may require users to have native OS's to have pcre shared library on board. Since gojsonsm is going to be pulled into the official couchbase directory, the build team has confirmed that it won't be an issue for all the different OSes that we currently support.