### PR TITLE
Fixes #58: Allow recursive function calls, and other fx additions

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -9,20 +9,21 @@ import (
 // Function related constants
 const (
 	MathFuncAbs   string = "mathAbs"
-	MathFuncAcos  string = "mathFuncAcos"
-	MathFuncAsin  string = "mathFuncAsin"
-	MathFuncAtan  string = "mathFuncAtan"
+	MathFuncAcos  string = "mathAcos"
+	MathFuncAsin  string = "mathAsin"
+	MathFuncAtan  string = "mathAtan"
 	MathFuncCeil  string = "mathCeil"
 	MathFuncCos   string = "mathCos"
-	MathFuncExp   string = "mathFuncExp"
-	MathFuncFloor string = "mathFuncFloor"
-	MathFuncLog   string = "mathFuncLog"
-	MathFuncLn    string = "mathFuncLn"
+	MathFuncExp   string = "mathExp"
+	MathFuncFloor string = "mathFloor"
+	MathFuncLog   string = "mathLog"
+	MathFuncLn    string = "mathLn"
+	MathFuncPi    string = "mathPi"
+	MathFuncPow   string = "mathPow"
 	MathFuncRound string = "mathRound"
 	MathFuncSin   string = "mathSin"
 	MathFuncSqrt  string = "mathSqrt"
 	MathFuncTan   string = "mathTan"
-	MathFuncPow   string = "mathPow"
 )
 
 // Parser related constants

--- a/constants.go
+++ b/constants.go
@@ -22,6 +22,7 @@ const (
 	MathFuncSin   string = "mathSin"
 	MathFuncSqrt  string = "mathSqrt"
 	MathFuncTan   string = "mathTan"
+	MathFuncPow   string = "mathPow"
 )
 
 // Parser related constants
@@ -90,3 +91,8 @@ const (
 	matchOp   opTokenContext = iota
 	noFieldOp opTokenContext = iota
 )
+
+// Function helpers
+type checkAndGetKeyFunc func(string) (bool, string)
+type funcNameType string
+type funcRecursiveIdx int

--- a/expression.go
+++ b/expression.go
@@ -126,7 +126,10 @@ type FuncExpr struct {
 
 func (expr FuncExpr) String() string {
 	rootStr := fmt.Sprintf("func:%s(", expr.FuncName)
-	for _, param := range expr.Params {
+	for i, param := range expr.Params {
+		if i > 0 {
+			rootStr += ","
+		}
 		rootStr += param.String()
 	}
 	rootStr += ")"

--- a/fastval_math.go
+++ b/fastval_math.go
@@ -42,6 +42,7 @@ func FastValMathAbs(val FastVal) FastVal {
 }
 
 type floatToFloatOp func(float64) float64
+type float2ToFloatOp func(float64, float64) float64
 
 func genericFastValFloatOp(val FastVal, op floatToFloatOp) FastVal {
 	if val.IsNumeric() {
@@ -49,6 +50,14 @@ func genericFastValFloatOp(val FastVal, op floatToFloatOp) FastVal {
 	}
 
 	return NewInvalidFastVal()
+}
+
+func genericFastVal2FloatsOp(val, val1 FastVal, op float2ToFloatOp) FastVal {
+	if !val.IsNumeric() || !val1.IsNumeric() {
+		return NewInvalidFastVal()
+	}
+
+	return NewFloatFastVal(op(val.AsFloat(), val1.AsFloat()))
 }
 
 func FastValMathSqrt(val FastVal) FastVal {
@@ -97,4 +106,8 @@ func FastValMathCeil(val FastVal) FastVal {
 
 func FastValMathFloor(val FastVal) FastVal {
 	return genericFastValFloatOp(val, math.Floor)
+}
+
+func FastValMathPow(val, val1 FastVal) FastVal {
+	return genericFastVal2FloatsOp(val, val1, math.Pow)
 }

--- a/fastval_math.go
+++ b/fastval_math.go
@@ -111,3 +111,7 @@ func FastValMathFloor(val FastVal) FastVal {
 func FastValMathPow(val, val1 FastVal) FastVal {
 	return genericFastVal2FloatsOp(val, val1, math.Pow)
 }
+
+func FastValMathPi() FastVal {
+	return NewFloatFastVal(math.Pi)
+}

--- a/fastval_math.go
+++ b/fastval_math.go
@@ -111,7 +111,3 @@ func FastValMathFloor(val FastVal) FastVal {
 func FastValMathPow(val, val1 FastVal) FastVal {
 	return genericFastVal2FloatsOp(val, val1, math.Pow)
 }
-
-func FastValMathPi() FastVal {
-	return NewFloatFastVal(math.Pi)
-}

--- a/matcher.go
+++ b/matcher.go
@@ -153,6 +153,8 @@ func (m *Matcher) resolveFunc(fn FuncRef, activeLit *FastVal) FastVal {
 		p1 := m.resolveParam(fn.Params[0], activeLit)
 		p2 := m.resolveParam(fn.Params[1], activeLit)
 		return FastValMathPow(p1, p2)
+	case MathFuncPi:
+		return FastValMathPi()
 	default:
 		panic(fmt.Sprintf("encountered unexpected function name: %v", fn.FuncName))
 	}

--- a/matcher.go
+++ b/matcher.go
@@ -149,8 +149,12 @@ func (m *Matcher) resolveFunc(fn FuncRef, activeLit *FastVal) FastVal {
 	case MathFuncFloor:
 		p1 := m.resolveParam(fn.Params[0], activeLit)
 		return FastValMathFloor(p1)
+	case MathFuncPow:
+		p1 := m.resolveParam(fn.Params[0], activeLit)
+		p2 := m.resolveParam(fn.Params[1], activeLit)
+		return FastValMathPow(p1, p2)
 	default:
-		panic("encountered unexpected function name")
+		panic(fmt.Sprintf("encountered unexpected function name: %v", fn.FuncName))
 	}
 }
 

--- a/matcher.go
+++ b/matcher.go
@@ -153,8 +153,6 @@ func (m *Matcher) resolveFunc(fn FuncRef, activeLit *FastVal) FastVal {
 		p1 := m.resolveParam(fn.Params[0], activeLit)
 		p2 := m.resolveParam(fn.Params[1], activeLit)
 		return FastValMathPow(p1, p2)
-	case MathFuncPi:
-		return FastValMathPi()
 	default:
 		panic(fmt.Sprintf("encountered unexpected function name: %v", fn.FuncName))
 	}

--- a/simpleParser.go
+++ b/simpleParser.go
@@ -4,6 +4,7 @@ package gojsonsm
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"strconv"
 	"strings"
@@ -81,6 +82,13 @@ var func0VarTranslateTable map[string]string = map[string]string{
 // Two variables function patterns
 var func2VarsTranslateTable map[string]string = map[string]string{
 	"POWER": MathFuncPow,
+}
+
+func funcIsConstantType(fxName string) (bool, interface{}) {
+	if fxName == MathFuncPi {
+		return true, float64(math.Pi)
+	}
+	return false, nil
 }
 
 func getOutputFuncName(userInput string) string {
@@ -1356,6 +1364,12 @@ func (ctx *expressionParserContext) outputFunc(pos int) (Expression, error) {
 	}
 
 	out.FuncName = getOutputFuncName(helper.args[curLevel][0].(string))
+
+	// For constants, just return a plain value to speed up the match execution
+	if isConst, val := funcIsConstantType(out.FuncName); isConst && len(helper.args[curLevel]) == 1 {
+		return outputValueInternal(val)
+	}
+
 	for i := 1; i < len(helper.args[curLevel]); i++ {
 		if funcIdx, isFunc := helper.args[curLevel][i].(funcRecursiveIdx); isFunc {
 			helper.lvlMarker = int(funcIdx)

--- a/simpleParser_test.go
+++ b/simpleParser_test.go
@@ -2066,6 +2066,31 @@ func TestParserExpressionOutputArrayEqualsMissing(t *testing.T) {
 	assert.False(match)
 }
 
+//func TestParserPlayground(t *testing.T) {
+//	assert := assert.New(t)
+//
+//	matchJson := []byte(`
+//		["lessthan",
+//			["func", "mathPi"],
+//			["value", 0]
+//		]`)
+//
+//	jsonExpr, err := ParseJsonExpression(matchJson)
+//	assert.Nil(err)
+//
+//	strExpr := "PI() <  0"
+//	ctx, err := NewExpressionParserCtx(strExpr)
+//	assert.Nil(err)
+//
+//	err = ctx.parse()
+//	assert.Nil(err)
+//
+//	simpleExpr, err := ctx.outputExpression()
+//	assert.Nil(err)
+//
+//	assert.Equal(jsonExpr.String(), simpleExpr.String())
+//}
+
 func TestParserExpressionMathRoundValues(t *testing.T) {
 	assert := assert.New(t)
 
@@ -2153,20 +2178,7 @@ func TestParserExpressionMathRoundValues2(t *testing.T) {
 func TestParserBunchaMathFuncs(t *testing.T) {
 	assert := assert.New(t)
 
-	matchJson := []byte(`
-		["equals",
-		    ["func", "mathPow",
-		        ["field", "squaredNum"],
-			    ["value", 2]
-			],
-			["value", 16]
-		]`)
-
-	jsonExpr, err := ParseJsonExpression(matchJson)
-	assert.Nil(err)
-
-	strExpr := "POWER(squaredNum,2) == 16"
-	//	strExpr := "ABS(negNum) ==  5 && SQRT(squaredNum) > 1"
+	strExpr := "ABS(negNum) ==  5 && SQRT(squaredNum) > 1 && POWER(squaredNum,2) == 16 && negNum < PI()"
 	ctx, err := NewExpressionParserCtx(strExpr)
 	assert.Nil(err)
 
@@ -2175,8 +2187,6 @@ func TestParserBunchaMathFuncs(t *testing.T) {
 
 	simpleExpr, err := ctx.outputExpression()
 	assert.Nil(err)
-
-	assert.Equal(jsonExpr.String(), simpleExpr.String())
 
 	var trans Transformer
 	matchDef := trans.Transform([]Expression{simpleExpr})

--- a/simpleParser_test.go
+++ b/simpleParser_test.go
@@ -2153,7 +2153,20 @@ func TestParserExpressionMathRoundValues2(t *testing.T) {
 func TestParserBunchaMathFuncs(t *testing.T) {
 	assert := assert.New(t)
 
-	strExpr := "ABS(negNum) ==  5 && SQRT(squaredNum) > 1"
+	matchJson := []byte(`
+		["equals",
+		    ["func", "mathPow",
+		        ["field", "squaredNum"],
+			    ["value", 2]
+			],
+			["value", 16]
+		]`)
+
+	jsonExpr, err := ParseJsonExpression(matchJson)
+	assert.Nil(err)
+
+	strExpr := "POWER(squaredNum,2) == 16"
+	//	strExpr := "ABS(negNum) ==  5 && SQRT(squaredNum) > 1"
 	ctx, err := NewExpressionParserCtx(strExpr)
 	assert.Nil(err)
 
@@ -2162,6 +2175,8 @@ func TestParserBunchaMathFuncs(t *testing.T) {
 
 	simpleExpr, err := ctx.outputExpression()
 	assert.Nil(err)
+
+	assert.Equal(jsonExpr.String(), simpleExpr.String())
 
 	var trans Transformer
 	matchDef := trans.Transform([]Expression{simpleExpr})


### PR DESCRIPTION
The parser takes a whole function argument `FX(FX2(FX3(arg1, arg2...)))` where ... may contain recursive function calls, and parse them into `[][]interface{}`, in which FX resides in the 0th row, FX1 resides in the 1st row, etc.  The 0th column is always the FX name, with argument starting at 1th column, etc.

Thus, when outputting the function as a field, we are able to use the idx to refer to the level of recursion, and to grab the necessary value or fields associated with them. 

Another thing added here is to allow functions of no parameters, as well as functions with > 1 parameters.

The parser is still pretty strict about whitespaces and paren, etc. Function calls cannot have whitespaces in them right now. (i.e. `POWER(2,PI())`)
I don't want to address them here in this PR but will do so in a near future PR.