### PR TITLE
Fixes #68 - add matcher support for time and date comparison

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -8,23 +8,24 @@ import (
 
 // Function related constants
 const (
-	DateFunc      string = "date"
-	MathFuncAbs   string = "mathAbs"
-	MathFuncAcos  string = "mathAcos"
-	MathFuncAsin  string = "mathAsin"
-	MathFuncAtan  string = "mathAtan"
-	MathFuncCeil  string = "mathCeil"
-	MathFuncCos   string = "mathCos"
-	MathFuncExp   string = "mathExp"
-	MathFuncFloor string = "mathFloor"
-	MathFuncLog   string = "mathLog"
-	MathFuncLn    string = "mathLn"
-	MathFuncPi    string = "mathPi"
-	MathFuncPow   string = "mathPow"
-	MathFuncRound string = "mathRound"
-	MathFuncSin   string = "mathSin"
-	MathFuncSqrt  string = "mathSqrt"
-	MathFuncTan   string = "mathTan"
+	DateFunc       string = "date"
+	DateFuncParser string = "DATE"
+	MathFuncAbs    string = "mathAbs"
+	MathFuncAcos   string = "mathAcos"
+	MathFuncAsin   string = "mathAsin"
+	MathFuncAtan   string = "mathAtan"
+	MathFuncCeil   string = "mathCeil"
+	MathFuncCos    string = "mathCos"
+	MathFuncExp    string = "mathExp"
+	MathFuncFloor  string = "mathFloor"
+	MathFuncLog    string = "mathLog"
+	MathFuncLn     string = "mathLn"
+	MathFuncPi     string = "mathPi"
+	MathFuncPow    string = "mathPow"
+	MathFuncRound  string = "mathRound"
+	MathFuncSin    string = "mathSin"
+	MathFuncSqrt   string = "mathSqrt"
+	MathFuncTan    string = "mathTan"
 )
 
 // Parser related constants
@@ -44,6 +45,7 @@ var ErrorMissingQuote error = fmt.Errorf("Invalid token - could not find matchin
 var ErrorEmptyLiteral error = fmt.Errorf("Literals cannot be empty")
 var ErrorEmptyToken error = fmt.Errorf("Token cannot be empty")
 var ErrorInvalidFuncArgs error = fmt.Errorf("Unable to parse arguments to specified built in function")
+var ErrorInvalidTimeFormat error = fmt.Errorf("Invalid given time format")
 var ErrorPcreNotSupported error = fmt.Errorf("Error: Current instance of gojsonsm does not have native PCRE support compiled")
 var ErrorFieldPathNotFound error = fmt.Errorf("Error: Unable to find internally stored field path")
 var ErrorMalformedFxInternals error = fmt.Errorf("Error: Malformed internal function helper")

--- a/constants.go
+++ b/constants.go
@@ -8,6 +8,7 @@ import (
 
 // Function related constants
 const (
+	DateFunc      string = "date"
 	MathFuncAbs   string = "mathAbs"
 	MathFuncAcos  string = "mathAcos"
 	MathFuncAsin  string = "mathAsin"

--- a/expression.go
+++ b/expression.go
@@ -43,6 +43,14 @@ func (expr ValueExpr) String() string {
 	return fmt.Sprintf("%v", expr.Value)
 }
 
+type TimeExpr struct {
+	Time interface{}
+}
+
+func (expr TimeExpr) String() string {
+	return fmt.Sprintf("%v", expr.Time)
+}
+
 type RegexExpr struct {
 	Regex interface{}
 }

--- a/expression_json.go
+++ b/expression_json.go
@@ -282,6 +282,12 @@ func parseJsonRegex(data []interface{}) (Expression, error) {
 	}, nil
 }
 
+func parseJsonTime(data []interface{}) (Expression, error) {
+	return TimeExpr{
+		data[1],
+	}, nil
+}
+
 func parseJsonSubexpr(data []interface{}) (Expression, error) {
 	exprType, ok := data[0].(string)
 	if !ok {
@@ -328,6 +334,8 @@ func parseJsonSubexpr(data []interface{}) (Expression, error) {
 		return parseJsonLike(data)
 	case "regex":
 		return parseJsonRegex(data)
+	case "time":
+		return parseJsonTime(data)
 	}
 
 	return nil, errors.New("invalid expression type")

--- a/expression_json.go
+++ b/expression_json.go
@@ -283,6 +283,9 @@ func parseJsonRegex(data []interface{}) (Expression, error) {
 }
 
 func parseJsonTime(data []interface{}) (Expression, error) {
+	if dateStr, ok := data[1].(string); ok && !validTimeChecker(dateStr) {
+		return nil, ErrorInvalidTimeFormat
+	}
 	return TimeExpr{
 		data[1],
 	}, nil

--- a/expression_utils.go
+++ b/expression_utils.go
@@ -46,6 +46,7 @@ func fetchExprFieldRefsRecurse(expr Expression, loopVars []VariableID, fields []
 	case ValueExpr:
 	case RegexExpr:
 	case PcreExpr:
+	case TimeExpr:
 	case FuncExpr:
 		for _, subexpr := range expr.Params {
 			fields = fetchExprFieldRefsRecurse(subexpr, loopVars, fields)

--- a/fastval.go
+++ b/fastval.go
@@ -87,7 +87,7 @@ func (val FastVal) String() string {
 		// TODO: Implement array value stringification
 		return "??OBJECT??"
 	case TimeValue:
-		return val.AsTime().String()
+		return val.GetTime().String()
 	}
 
 	panic("unexpected data type")
@@ -160,6 +160,10 @@ func (val FastVal) GetUint() uint64 {
 
 func (val FastVal) GetFloat() float64 {
 	return *(*float64)(unsafe.Pointer(&val.rawData))
+}
+
+func (val FastVal) GetTime() *time.Time {
+	return val.data.(*time.Time)
 }
 
 func (val FastVal) AsInt() int64 {

--- a/fastval_date.go
+++ b/fastval_date.go
@@ -1,0 +1,31 @@
+package gojsonsm
+
+import (
+	"fmt"
+	"time"
+)
+
+func FastValDateFunc(val FastVal) FastVal {
+	switch val.Type() {
+	case TimeValue:
+		return val
+	case JsonStringValue:
+		fallthrough
+	case BinStringValue:
+		tmpVal, _ := val.ToBinString()
+		str := fmt.Sprintf(`%s`, tmpVal.sliceData)
+		timeVal, err := time.Parse(time.RFC3339, str)
+		if err != nil {
+			return NewInvalidFastVal()
+		}
+		return NewTimeFastVal(&timeVal)
+	case StringValue:
+		str := val.data.(string)
+		timeVal, err := time.Parse(time.RFC3339, str)
+		if err != nil {
+			return NewInvalidFastVal()
+		}
+		return NewTimeFastVal(&timeVal)
+	}
+	return NewInvalidFastVal()
+}

--- a/fastval_date.go
+++ b/fastval_date.go
@@ -2,8 +2,29 @@ package gojsonsm
 
 import (
 	"fmt"
+	"regexp"
 	"time"
 )
+
+var iso8601Year *regexp.Regexp = regexp.MustCompile(`^(19|20)\d\d$`)
+var iso8601YearAndMonth *regexp.Regexp = regexp.MustCompile(`^(19|20)\d\d[- /.](0[1-9]|1[012])$`)
+var iso8601CompleteDate *regexp.Regexp = regexp.MustCompile(`^(19|20)\d\d[- /.](0[1-9]|1[012])[- /.](0[1-9]|[12][0-9]|3[01])$`)
+
+func validTimeChecker(s string) bool {
+	_, err := time.Parse(time.RFC3339, s)
+	return err == nil || iso8601Year.MatchString(s) || iso8601YearAndMonth.MatchString(s) || iso8601CompleteDate.MatchString(s)
+}
+
+func isoToRfc(str string) string {
+	if iso8601Year.MatchString(str) {
+		str = fmt.Sprintf(`%s-01-01T00:00:00Z`, str)
+	} else if iso8601YearAndMonth.MatchString(str) {
+		str = fmt.Sprintf(`%s-01T00:00:00Z`, str)
+	} else if iso8601CompleteDate.MatchString(str) {
+		str = fmt.Sprintf(`%sT00:00:00Z`, str)
+	}
+	return str
+}
 
 func FastValDateFunc(val FastVal) FastVal {
 	switch val.Type() {
@@ -12,15 +33,24 @@ func FastValDateFunc(val FastVal) FastVal {
 	case JsonStringValue:
 		fallthrough
 	case BinStringValue:
-		tmpVal, _ := val.ToBinString()
-		str := fmt.Sprintf(`%s`, tmpVal.sliceData)
+		binVal, _ := val.ToBinString()
+		var str string
+		if iso8601Year.Match(binVal.sliceData) {
+			str = fmt.Sprintf(`%s-01-01T00:00:00Z`, binVal.sliceData)
+		} else if iso8601YearAndMonth.Match(binVal.sliceData) {
+			str = fmt.Sprintf(`%s-01T00:00:00Z`, binVal.sliceData)
+		} else if iso8601CompleteDate.Match(binVal.sliceData) {
+			str = fmt.Sprintf(`%sT00:00:00Z`, binVal.sliceData)
+		} else {
+			str = fmt.Sprintf(`%s`, binVal.sliceData)
+		}
 		timeVal, err := time.Parse(time.RFC3339, str)
 		if err != nil {
 			return NewInvalidFastVal()
 		}
 		return NewTimeFastVal(&timeVal)
 	case StringValue:
-		str := val.data.(string)
+		str := isoToRfc(val.data.(string))
 		timeVal, err := time.Parse(time.RFC3339, str)
 		if err != nil {
 			return NewInvalidFastVal()
@@ -28,4 +58,13 @@ func FastValDateFunc(val FastVal) FastVal {
 		return NewTimeFastVal(&timeVal)
 	}
 	return NewInvalidFastVal()
+}
+
+func GetNewTimeFastVal(input string) (FastVal, error) {
+	str := isoToRfc(input)
+	if timeVal, err := time.Parse(time.RFC3339, str); err == nil {
+		return NewFastVal(&timeVal), nil
+	} else {
+		return NewInvalidFastVal(), err
+	}
 }

--- a/matcher.go
+++ b/matcher.go
@@ -153,6 +153,9 @@ func (m *Matcher) resolveFunc(fn FuncRef, activeLit *FastVal) FastVal {
 		p1 := m.resolveParam(fn.Params[0], activeLit)
 		p2 := m.resolveParam(fn.Params[1], activeLit)
 		return FastValMathPow(p1, p2)
+	case DateFunc:
+		p1 := m.resolveParam(fn.Params[0], activeLit)
+		return FastValDateFunc(p1)
 	default:
 		panic(fmt.Sprintf("encountered unexpected function name: %v", fn.FuncName))
 	}
@@ -186,6 +189,7 @@ func (m *Matcher) matchOp(op *OpNode, litVal *FastVal) error {
 		return nil
 	}
 
+	// TODO - what to do if it's a time val?
 	lhsVal := NewMissingFastVal()
 	if op.Lhs != nil {
 		lhsVal = m.resolveParam(op.Lhs, litVal)

--- a/matcher.go
+++ b/matcher.go
@@ -189,7 +189,6 @@ func (m *Matcher) matchOp(op *OpNode, litVal *FastVal) error {
 		return nil
 	}
 
-	// TODO - what to do if it's a time val?
 	lhsVal := NewMissingFastVal()
 	if op.Lhs != nil {
 		lhsVal = m.resolveParam(op.Lhs, litVal)

--- a/simpleParser.go
+++ b/simpleParser.go
@@ -59,21 +59,21 @@ var fieldIndexNoLeadingZero *regexp.Regexp = regexp.MustCompile(`[^0][0-9]+`)
 
 // Functions patterns
 var funcTranslateTable map[string]string = map[string]string{
-	"ABS":   MathFuncAbs,
-	"ACOS":  MathFuncAcos,
-	"ASIN":  MathFuncAsin,
-	"ATAN":  MathFuncAtan,
-	"CEIL":  MathFuncCeil,
-	"COS":   MathFuncCos,
-	"DATE":  DateFunc,
-	"EXP":   MathFuncExp,
-	"FLOOR": MathFuncFloor,
-	"LOG":   MathFuncLog,
-	"LN":    MathFuncLn,
-	"SIN":   MathFuncSin,
-	"TAN":   MathFuncTan,
-	"ROUND": MathFuncRound,
-	"SQRT":  MathFuncSqrt,
+	"ABS":          MathFuncAbs,
+	"ACOS":         MathFuncAcos,
+	"ASIN":         MathFuncAsin,
+	"ATAN":         MathFuncAtan,
+	"CEIL":         MathFuncCeil,
+	"COS":          MathFuncCos,
+	DateFuncParser: DateFunc,
+	"EXP":          MathFuncExp,
+	"FLOOR":        MathFuncFloor,
+	"LOG":          MathFuncLog,
+	"LN":           MathFuncLn,
+	"SIN":          MathFuncSin,
+	"TAN":          MathFuncTan,
+	"ROUND":        MathFuncRound,
+	"SQRT":         MathFuncSqrt,
 }
 
 var func0VarTranslateTable map[string]string = map[string]string{
@@ -1696,6 +1696,9 @@ func (helper *funcOutputHelper) resolveRecursiveFuncs(token string, lastFunc str
 			valueString := strings.TrimPrefix(subMatches[i], delim)
 			valueString = strings.TrimSuffix(valueString, delim)
 			helper.args[fxIdx] = append(helper.args[fxIdx], valueString)
+			if lastFunc == DateFuncParser && !validTimeChecker(valueString) {
+				return ErrorInvalidTimeFormat
+			}
 		} else if isNumericValue, ok := valueCheck(subMatches[i]).(bool); ok && isNumericValue {
 			helper.args[fxIdx] = append(helper.args[fxIdx], subMatches[i])
 		} else {

--- a/simpleParser.go
+++ b/simpleParser.go
@@ -65,6 +65,7 @@ var funcTranslateTable map[string]string = map[string]string{
 	"ATAN":  MathFuncAtan,
 	"CEIL":  MathFuncCeil,
 	"COS":   MathFuncCos,
+	"DATE":  DateFunc,
 	"EXP":   MathFuncExp,
 	"FLOOR": MathFuncFloor,
 	"LOG":   MathFuncLog,

--- a/simpleParser_test.go
+++ b/simpleParser_test.go
@@ -2511,3 +2511,76 @@ func TestParserDateFunc2(t *testing.T) {
 	assert.Nil(err)
 	assert.True(match)
 }
+
+func TestParserIso8601(t *testing.T) {
+	assert := assert.New(t)
+
+	yrOnly := "1991"
+	assert.True(iso8601Year.MatchString(yrOnly))
+	assert.False(iso8601YearAndMonth.MatchString(yrOnly))
+	assert.False(iso8601CompleteDate.MatchString(yrOnly))
+
+	yrMonth := "1991-01"
+	assert.False(iso8601Year.MatchString(yrMonth))
+	assert.True(iso8601YearAndMonth.MatchString(yrMonth))
+	assert.False(iso8601CompleteDate.MatchString(yrMonth))
+
+	yrMonthDate := "1991-01-23"
+	assert.False(iso8601Year.MatchString(yrMonthDate))
+	assert.False(iso8601YearAndMonth.MatchString(yrMonthDate))
+	assert.True(iso8601CompleteDate.MatchString(yrMonthDate))
+}
+
+func TestParserDateFunc3(t *testing.T) {
+	assert := assert.New(t)
+
+	strExpr := "DATE(transactionDate) <  DATE(\"2018-01-02\")"
+	ctx, err := NewExpressionParserCtx(strExpr)
+	assert.Nil(err)
+
+	err = ctx.parse()
+	assert.Nil(err)
+
+	simpleExpr, err := ctx.outputExpression()
+	assert.Nil(err)
+
+	var trans Transformer
+	matchDef := trans.Transform([]Expression{simpleExpr})
+	assert.NotNil(matchDef)
+
+	m := NewMatcher(matchDef)
+	userData := map[string]interface{}{
+		"transactionDate": "2017-01-02",
+	}
+
+	udMarsh, _ := json.Marshal(userData)
+	match, err := m.Match(udMarsh)
+	assert.Nil(err)
+	assert.True(match)
+}
+
+func TestParserDateFuncNeg(t *testing.T) {
+	assert := assert.New(t)
+
+	// Missing Z
+	matchJson := []byte(`
+	["equals",
+		["func", "date",
+			["field", "transactionDate"]
+		],
+		["func", "date",
+			["time", "2018-01-02T03:04:05"]
+		]
+	]`)
+
+	_, err := ParseJsonExpression(matchJson)
+	assert.Equal(ErrorInvalidTimeFormat, err)
+
+	// Missing T
+	strExpr := "DATE(transactionDate) <  DATE(\"2018-01-02-01:02:03\")"
+	ctx, err := NewExpressionParserCtx(strExpr)
+	assert.Nil(err)
+
+	err = ctx.parse()
+	assert.Equal(ErrorInvalidTimeFormat, err)
+}

--- a/transform.go
+++ b/transform.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"time"
 )
 
 type resolvedFieldRef struct {
@@ -324,6 +325,9 @@ func (t *Transformer) makeDataRefRecurse(expr Expression, context nodeRef, isRoo
 			FuncName: expr.FuncName,
 			Params:   params,
 		}, nil
+	case TimeExpr:
+		timeVal, err := time.Parse(time.RFC3339, expr.Time.(string))
+		return NewFastVal(&timeVal), err
 	}
 
 	return nil, errors.New("unsupported expression in parameter")

--- a/transform.go
+++ b/transform.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
-	"time"
 )
 
 type resolvedFieldRef struct {
@@ -326,8 +325,7 @@ func (t *Transformer) makeDataRefRecurse(expr Expression, context nodeRef, isRoo
 			Params:   params,
 		}, nil
 	case TimeExpr:
-		timeVal, err := time.Parse(time.RFC3339, expr.Time.(string))
-		return NewFastVal(&timeVal), err
+		return GetNewTimeFastVal(expr.Time.(string))
 	}
 
 	return nil, errors.New("unsupported expression in parameter")


### PR DESCRIPTION
Given that N1QL uses ISO8601 and golang's time library supports RFC3339, there are some code to bridge the gap.
I'm not sure if there are better ways to reuse time objects though, but internally time structs are cheap so hopefully garbage isn't a problem when doing matching.