### PR TITLE
Add perf tags for benchmark tests

### DIFF
--- a/fastMatcher_bench_test.go
+++ b/fastMatcher_bench_test.go
@@ -1,5 +1,7 @@
 package gojsonsm
 
+// +build perf
+
 import (
 	"testing"
 )

--- a/randdata.go
+++ b/randdata.go
@@ -1,5 +1,7 @@
 // Copyright 2018 Couchbase, Inc. All rights reserved.
 
+// +build perf
+
 package gojsonsm
 
 import (


### PR DESCRIPTION
This is to allow couchbase server build to avoid the need to add icrowley to godeps.