### PR TITLE
Optimize by minimizing len() calls

### DIFF
--- a/fastlitparse.go
+++ b/fastlitparse.go
@@ -51,8 +51,17 @@ func (p *fastLitParser) ParseString(bytes []byte) []byte {
 	return bytes[1 : len(bytes)-1]
 }
 
+func (p *fastLitParser) ParseStringWLen(bytes []byte, size int) []byte {
+	return bytes[1 : size-1]
+}
+
 func (p *fastLitParser) ParseEscString(bytes []byte) []byte {
 	bytesOut, _ := unescapeJsonString(bytes[1:len(bytes)-1], p.tmpBytesData[:])
+	return bytesOut
+}
+
+func (p *fastLitParser) ParseEscStringWLen(bytes []byte, size int) []byte {
+	bytesOut, _ := unescapeJsonString(bytes[1:size-1], p.tmpBytesData[:])
 	return bytesOut
 }
 

--- a/jsontokenizer_test.go
+++ b/jsontokenizer_test.go
@@ -10,7 +10,7 @@ import (
 func testTokenizedStep(t *testing.T, tok *jsonTokenizer, expectedToken tokenType, expectedTokenStr string) {
 	t.Helper()
 
-	token, tokenData, err := tok.Step()
+	token, tokenData, _, err := tok.Step()
 	if err != nil {
 		t.Fatalf("encountered stepping error: %s", err)
 	}
@@ -175,7 +175,7 @@ func TestTokenizerLong(t *testing.T) {
 	var tok jsonTokenizer
 	tok.Reset(dataBytes)
 	for {
-		token, _, err := tok.Step()
+		token, _, _, err := tok.Step()
 		if err != nil {
 			panic(fmt.Sprintf("encountered stepping error: %s", err))
 		}
@@ -201,7 +201,7 @@ func BenchmarkTokenize(b *testing.B) {
 		tok.Reset(dataBytes)
 
 		for {
-			token, _, err := tok.Step()
+			token, _, _, err := tok.Step()
 			if err != nil {
 				panic(fmt.Sprintf("encountered stepping error: %s", err))
 			}


### PR DESCRIPTION
While doing XDCR performance testing/optimization iterations, we find that calling len() in repeated ops could be quite expensive over time. Step() is one of the bigger offenders in CPU profile, and this change should remove a lot of len() calls that aren't really necessary.

Running local benchmark test shows improvements across the board:

Master:
```
neil.huang@NeilsMacbookPro:~/source/couchbase/godeps/src/github.com/couchbase/gojsonsm$ go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/couchbase/gojsonsm
BenchmarkBinTree-8             	20000000	        66.2 ns/op
BenchmarkParseString-8         	300000000	         5.88 ns/op
BenchmarkParseBigString-8      	300000000	         5.94 ns/op
BenchmarkParseEscString-8      	30000000	        52.9 ns/op
BenchmarkParseBigEscString-8   	10000000	       170 ns/op
BenchmarkParseInteger-8        	100000000	        12.7 ns/op
BenchmarkParseNumber-8         	30000000	        55.0 ns/op
BenchmarkParseNull-8           	200000000	         7.09 ns/op
BenchmarkParseTrue-8           	200000000	         8.34 ns/op
BenchmarkParseFalse-8          	200000000	         7.14 ns/op
BenchmarkTokenize-8            	   30000	     45472 ns/op	 343.63 MB/s
PASS
ok  	github.com/couchbase/gojsonsm	21.338s
```

With len() calls removed:

```
neil.huang@NeilsMacbookPro:~/source/couchbase/godeps/src/github.com/couchbase/gojsonsm$ go test -bench=.
goos: darwin
goarch: amd64
pkg: github.com/couchbase/gojsonsm
BenchmarkBinTree-8             	20000000	        65.5 ns/op
BenchmarkParseString-8         	300000000	         5.71 ns/op
BenchmarkParseBigString-8      	300000000	         5.84 ns/op
BenchmarkParseEscString-8      	30000000	        51.4 ns/op
BenchmarkParseBigEscString-8   	10000000	       163 ns/op
BenchmarkParseInteger-8        	100000000	        12.3 ns/op
BenchmarkParseNumber-8         	30000000	        54.5 ns/op
BenchmarkParseNull-8           	200000000	         6.80 ns/op
BenchmarkParseTrue-8           	200000000	         7.98 ns/op
BenchmarkParseFalse-8          	200000000	         6.88 ns/op
BenchmarkTokenize-8            	   30000	     42358 ns/op	 368.90 MB/s
PASS
ok  	github.com/couchbase/gojsonsm	20.686s
```