### PR TITLE
MB-33618 - change EXISTS syntax to match that of N1QL

### DIFF
--- a/filterExprParser_test.go
+++ b/filterExprParser_test.go
@@ -271,7 +271,7 @@ func TestFilterExpressionParser(t *testing.T) {
 	assert.Equal("metaKey", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
 	assert.True(fe.AndConditions[0].OrConditions[0].Operand.Op.IsEqual())
 	assert.Equal("value", fe.AndConditions[0].OrConditions[0].Operand.RHS.Value.String())
-	err = parser.ParseString("`[$%XDCRInternalMeta*%$]`.metaKey EXISTS AND `[$%XDCRInternalMeta*%$]`.metaKey = \"value\"", fe)
+	err = parser.ParseString("EXISTS (`[$%XDCRInternalMeta*%$]`.metaKey) AND `[$%XDCRInternalMeta*%$]`.metaKey = \"value\"", fe)
 	assert.Nil(err)
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
@@ -597,5 +597,9 @@ func TestFilterExpressionParser(t *testing.T) {
 	_, _, err = NewFilterExpressionParser("REGEXP_CONTAINS(METAS().ID(), \"something)")
 	assert.NotNil(err)
 	_, _, err = NewFilterExpressionParser("`field is unfinished = \"unfinished_value")
+	assert.NotNil(err)
+
+	// Discontinued
+	_, _, err = NewFilterExpressionParser("SomeKey EXISTS")
 	assert.NotNil(err)
 }


### PR DESCRIPTION
In N1QL, the EXISTS keyword is used as an unary operator on the target expression.
https://docs.couchbase.com/server/6.0/n1ql/n1ql-language-reference/collectionops.html#exists

An example would be:
_SELECT * FROM `travel-sample` as a WHERE country = "United States" AND EXISTS ( SELECT * FROM `travel-sample` as b WHERE type = "airline" );_

Currently, XDCR advanced filtering uses EXISTS for checking if a field exists or not. 
_SomeKeyInJSONDocument EXISTS_

However, to become more aligned with the N1QL usage, EXISTS should be used as an operator in front of the field variables. The proposal for XDCR Filtering usage of the EXISTS keyword will result in:

_EXISTS ( SomeKeyInJsonDocument )_
 
The previous method of using EXISTS will be unsupported, and will result in syntax error.