### PR TITLE
Fixes #99 - int comparison to a large float that overflows an int64 s…

### DIFF
--- a/fastval.go
+++ b/fastval.go
@@ -302,9 +302,26 @@ func (val FastVal) ToJsonString() (FastVal, error) {
 	return val, errors.New("invalid type coercion")
 }
 
+func (val FastVal) floatToIntOverflows() bool {
+	floatVal := val.GetFloat()
+
+	// Instead of using math constants that could potentially lead to rounding errors,
+	// force a float-to-float comparison here
+	if !(floatVal >= math.MinInt64 && floatVal <= math.MaxInt64) {
+		return true
+	} else {
+		return false
+	}
+}
+
 func (val FastVal) compareInt(other FastVal) int {
+	if other.dataType == FloatValue && other.floatToIntOverflows() {
+		return val.compareFloat(other)
+	}
+
 	intVal := val.AsInt()
 	intOval := other.AsInt()
+
 	if intVal < intOval {
 		return -1
 	} else if intVal > intOval {

--- a/filterExprParser_test.go
+++ b/filterExprParser_test.go
@@ -206,7 +206,7 @@ func TestFilterExpressionParser(t *testing.T) {
 	userData = map[string]interface{}{
 		"onePath": map[string]interface{}{
 			"field1": -2,
-			"field2": 2,
+			"field2": 2e30,
 		},
 	}
 	udMarsh, _ = json.Marshal(userData)


### PR DESCRIPTION
…hould use float comparison

It's possible that we lose some precision w.r.t to the integer when we convert it to a float, but it's potentially less problematic than having a overflow that causes signs to flip, leading to egregious results.