### PR TITLE
Fixes #90: Perform operations on the key of an object or array

### DIFF
--- a/fastval.go
+++ b/fastval.go
@@ -81,11 +81,9 @@ func (val FastVal) String() string {
 	case FalseValue:
 		return "false"
 	case ArrayValue:
-		// TODO: Implement array value stringification
-		return "??ARRAY??"
+		return "(array)" + string(val.sliceData)
 	case ObjectValue:
-		// TODO: Implement array value stringification
-		return "??OBJECT??"
+		return "(object)" + string(val.sliceData)
 	case TimeValue:
 		return val.GetTime().String()
 	case RegexValue:
@@ -392,6 +390,45 @@ func (val FastVal) compareTime(other FastVal) int {
 	}
 }
 
+func (val FastVal) compareArray(other FastVal) int {
+	// TODO - need a better way but for now treat them the same
+	return val.compareObjArrData(other)
+}
+
+func (val FastVal) compareObject(other FastVal) int {
+	// TODO - need a better way but for now treat them the same
+	return val.compareObjArrData(other)
+}
+
+func (val FastVal) compareObjArrData(other FastVal) int {
+	var same bool
+	// Do not use reflect
+	switch val.dataType {
+	case ArrayValue:
+		fallthrough
+	case ObjectValue:
+		if len(val.sliceData) > len(other.sliceData) {
+			return 1
+		} else if len(val.sliceData) < len(other.sliceData) {
+			return -1
+		} else {
+			same = true
+			for i := range val.sliceData {
+				if val.sliceData[i] > other.sliceData[i] {
+					return 1
+				} else if val.sliceData[i] < other.sliceData[i] {
+					return -1
+				}
+			}
+		}
+	}
+	if same {
+		return 0
+	} else {
+		return -1
+	}
+}
+
 func (val FastVal) Compare(other FastVal) int {
 	switch val.dataType {
 	case IntValue:
@@ -418,6 +455,10 @@ func (val FastVal) Compare(other FastVal) int {
 		return val.compareBoolean(other)
 	case TimeValue:
 		return val.compareTime(other)
+	case ArrayValue:
+		return val.compareArray(other)
+	case ObjectValue:
+		return val.compareObject(other)
 	}
 
 	if val.dataType < other.dataType {
@@ -622,6 +663,22 @@ func NewTimeFastVal(value *time.Time) FastVal {
 	val := FastVal{
 		dataType: TimeValue,
 		data:     value,
+	}
+	return val
+}
+
+func NewObjectFastVal(value []byte) FastVal {
+	val := FastVal{
+		dataType:  ObjectValue,
+		sliceData: value,
+	}
+	return val
+}
+
+func NewArrayFastVal(value []byte) FastVal {
+	val := FastVal{
+		dataType:  ArrayValue,
+		sliceData: value,
 	}
 	return val
 }


### PR DESCRIPTION
The problem is that when we're iterating through, we lose track of the key of an array or key of an object, so any distinct op nodes on that key were never executed. 
The proposed solution address this specific scenario and leaves the others untouched (I believe).