### PR TITLE
Fixes #107:

### DIFF
--- a/fastval.go
+++ b/fastval.go
@@ -381,6 +381,15 @@ func (val FastVal) compareTime(other FastVal) int {
 	thisTime := val.AsTime()
 	otherTime := other.AsTime()
 
+	// Consider nil value as the smaller/earlier than non-nil values
+	if thisTime == nil && otherTime == nil {
+		return 0
+	} else if otherTime == nil && thisTime != nil {
+		return 1
+	} else if otherTime != nil && thisTime == nil {
+		return -1
+	}
+
 	if thisTime.Equal(*otherTime) {
 		return 0
 	} else if thisTime.After(*otherTime) {

--- a/fastval_date.go
+++ b/fastval_date.go
@@ -10,6 +10,12 @@ var iso8601Year *regexp.Regexp = regexp.MustCompile(`^(19|20)\d\d$`)
 var iso8601YearAndMonth *regexp.Regexp = regexp.MustCompile(`^(19|20)\d\d[- /.](0[1-9]|1[012])$`)
 var iso8601CompleteDate *regexp.Regexp = regexp.MustCompile(`^(19|20)\d\d[- /.](0[1-9]|1[012])[- /.](0[1-9]|[12][0-9]|3[01])$`)
 
+// For parsing date
+// Commonly used in couchbase demo and maybe other common use cases for parsing
+// Format: "YYYY-MM-DD HH:MM:SS"
+// Can easily convert to ISO 8601 internally
+var cbSampleDateFormat *regexp.Regexp = regexp.MustCompile(`^((19|20)\d\d[- /.](0[1-9]|1[012])[- /.](0[1-9]|[12][0-9]|3[01])) +(([0-1][0-9]|[2][0-3]):[0-5][0-9]:[0-5][0-9])$`)
+
 func validTimeChecker(s string) bool {
 	_, err := time.Parse(time.RFC3339, s)
 	return err == nil || iso8601Year.MatchString(s) || iso8601YearAndMonth.MatchString(s) || iso8601CompleteDate.MatchString(s)
@@ -41,6 +47,20 @@ func FastValDateFunc(val FastVal) FastVal {
 			str = fmt.Sprintf(`%s-01T00:00:00Z`, binVal.sliceData)
 		} else if iso8601CompleteDate.Match(binVal.sliceData) {
 			str = fmt.Sprintf(`%sT00:00:00Z`, binVal.sliceData)
+		} else if cbSampleDateFormat.Match(binVal.sliceData) {
+			// len() call is very expensive. Use .Match() first then FindSubmatch
+			submatches := cbSampleDateFormat.FindSubmatch(binVal.sliceData)
+			if len(submatches) == 7 {
+				// Must be 7 submatches in the form:
+				// 0: 2019-01-01 23:59:59
+				// 1: 2019-01-01
+				// 2: 20
+				// 3: 01
+				// 4: 01
+				// 5: 23:59:59
+				// 6: 23
+				str = fmt.Sprintf(`%sT%sZ`, submatches[1], submatches[5])
+			}
 		} else {
 			str = fmt.Sprintf(`%s`, binVal.sliceData)
 		}


### PR DESCRIPTION
  - Added support for a more generic couchbase sample bucket date format
  - Check before date comparisons to make sure to not execute on a nil fastval
  - Fixes parser to allow correct capturing of FEValue, and remove redundant checks
  - Added some basic date function syntax checks to prevent entering of invalid date formats,
    which may yield incorrect results since any invalid comparison returns a valid result of -1