### PR TITLE
Fixes #106:

### DIFF
--- a/filterExprParser_test.go
+++ b/filterExprParser_test.go
@@ -118,6 +118,12 @@ func TestFilterExpressionParser(t *testing.T) {
 	assert.Nil(err)
 
 	fe = &FilterExpression{}
+	err = parser.ParseString("((TRUE OR FALSE) AND (FALSE OR TRUE)) OR (TRUE AND TRUE)", fe)
+	assert.Nil(err)
+	expr, err = fe.OutputExpression()
+	assert.Nil(err)
+
+	fe = &FilterExpression{}
 	err = parser.ParseString("NOT NOT NOT TRUE", fe)
 	assert.Nil(err)
 	expr, err = fe.OutputExpression()
@@ -745,7 +751,7 @@ func TestFilterExpressionParser(t *testing.T) {
 	_, err = fe.OutputExpression()
 	assert.NotNil(err)
 
-	// For invalid date values, it will always return -1
+	// For invalid date values, it will be nil and should be smaller than any other valids
 	fe = &FilterExpression{}
 	err = parser.ParseString("DATE(fieldpath.path) < DATE(\"2019-01-01\")", fe)
 	expr, err = fe.OutputExpression()
@@ -761,4 +767,9 @@ func TestFilterExpressionParser(t *testing.T) {
 	udMarsh, _ = json.Marshal(userData)
 	match, err = m.Match(udMarsh)
 	assert.True(match)
+
+	// Invalid parenthesis
+	_, fe, err = NewFilterExpressionParser("((TRUE OR FALSE () AND TRUE))")
+	_, err = fe.OutputExpression()
+	assert.NotNil(err)
 }


### PR DESCRIPTION
  Checking parenthesis for subExpression during outputExpression leads to
  only counting the subExpression parenthesis as the final tally, and
  causes correct parenthesis cases to be incorrect as the prev counts are lost.

For example, the statement: `((TRUE OR FALSE) AND (FALSE OR TRUE))`

For the parenthesis check, it gets the total Open and total Close, which are 3 each. That is correct.

But during the OutputExpression() call for the subExpression, it counts 1 open and 2 closes:
```
GetTotalOpen on ( FALSE(bool) OR TRUE(bool) ) )
( FALSE(bool) OR TRUE(bool) ) ) returned: andOpen: 1 subOpen: 0 totalCnt: 1
GetTotalClose on ( FALSE(bool) OR TRUE(bool) ) )
( FALSE(bool) OR TRUE(bool) ) ) returned: andClose: 2 subClose: 0 totalCnt: 2
Open: 1 close: 2
```

As OutputExpression() calls parenthesis check un-necessarily on the subExpression, the count returns the final tally as 1 open and 2 closes, and returns a non-nil err. The count is invalid in the scope of the subExpression, but is valid in the overall expression.