### PR TITLE
Clarify parenthesis errors

### DIFF
--- a/filterExprParser.go
+++ b/filterExprParser.go
@@ -133,8 +133,10 @@ func (f *FilterExpression) outputExpressionNoParenCheck() (Expression, error) {
 
 // Outputs the head of the Expression match tree of which represents everything underneath
 func (f *FilterExpression) OutputExpression() (Expression, error) {
-	if f.GetTotalOpenParens() != f.GetTotalCloseParens() {
-		return nil, ErrorMalformedParenthesis
+	openParens := f.GetTotalOpenParens()
+	closeParens := f.GetTotalCloseParens()
+	if openParens != closeParens {
+		return nil, fmt.Errorf("%s: found %v open parentheses and %v close parentheses", ErrorMalformedParenthesis, openParens, closeParens)
 	}
 
 	return f.outputExpressionNoParenCheck()

--- a/filterExprParser_test.go
+++ b/filterExprParser_test.go
@@ -5,6 +5,7 @@ package gojsonsm
 import (
 	"encoding/json"
 	"github.com/stretchr/testify/assert"
+	"strings"
 	"testing"
 )
 
@@ -674,13 +675,15 @@ func TestFilterExpressionParser(t *testing.T) {
 	err = parser.ParseString("(TRUE) OR FALSE)", fe)
 	assert.Nil(err)
 	expr, err = fe.OutputExpression()
-	assert.Equal(ErrorMalformedParenthesis, err)
+	assert.NotNil(err)
+	assert.True(strings.Contains(err.Error(), ErrorMalformedParenthesis.Error()))
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("(((TRUE) OR FALSE) OR FALSE))", fe)
 	assert.Nil(err)
 	expr, err = fe.OutputExpression()
-	assert.Equal(ErrorMalformedParenthesis, err)
+	assert.NotNil(err)
+	assert.True(strings.Contains(err.Error(), ErrorMalformedParenthesis.Error()))
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("TRUE", fe)


### PR DESCRIPTION
Just to make it more user friendly by printing out # of parenthesis counted.