### PR TITLE
Fixes #111: Reorganize FilterExpressionParser grammar to allow recurs…

### DIFF
--- a/filterExprParser_test.go
+++ b/filterExprParser_test.go
@@ -5,7 +5,6 @@ package gojsonsm
 import (
 	"encoding/json"
 	"github.com/stretchr/testify/assert"
-	"strings"
 	"testing"
 )
 
@@ -22,99 +21,97 @@ func TestFilterExpressionParser(t *testing.T) {
 
 	err = parser.ParseString("TRUE OR FALSE AND NOT FALSE", fe)
 	assert.Nil(err)
-	assert.Equal(2, len(fe.AndConditions))
-	assert.Equal(1, len(fe.AndConditions[0].OrConditions))
-	assert.Equal(2, len(fe.AndConditions[1].OrConditions))
-	assert.NotNil(fe.AndConditions[1].OrConditions[1].Not)
+	assert.Equal(2, len(fe.FilterExpr.AndConditions))
+	assert.Equal(1, len(fe.FilterExpr.AndConditions[0].OrConditions))
+	assert.Equal(2, len(fe.FilterExpr.AndConditions[1].OrConditions))
+	assert.NotNil(fe.FilterExpr.AndConditions[1].OrConditions[1].Not)
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("((TRUE OR FALSE))", fe)
 	assert.Nil(err)
-	assert.Equal(2, len(fe.AndConditions))
-	assert.Equal(2, len(fe.AndConditions[0].OpenParens))
-	assert.Equal(2, len(fe.AndConditions[1].CloseParens))
+	assert.NotNil(fe.OpenParen)
+	assert.NotNil(fe.CloseParen)
+	assert.NotNil(fe.SubFilterExpr.OpenParen)
+	assert.NotNil(fe.SubFilterExpr.CloseParen)
+	assert.Equal(2, len(fe.SubFilterExpr.SubFilterExpr.FilterExpr.AndConditions))
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("(TRUE AND FALSE)", fe)
 	assert.Nil(err)
-	assert.Equal(1, len(fe.AndConditions))
+	assert.NotNil(fe.OpenParen)
+	assert.NotNil(fe.CloseParen)
+	assert.Equal(1, len(fe.SubFilterExpr.FilterExpr.AndConditions))
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("(TRUE OR FALSE) AND (FALSE OR TRUE)", fe)
 	assert.Nil(err)
-	assert.Equal(2, len(fe.AndConditions))
-	assert.Equal(1, len(fe.SubFilterExpr))
-	assert.Equal(2, len(fe.SubFilterExpr[0].AndConditions))
+	assert.NotNil(fe.OpenParen)
+	assert.NotNil(fe.CloseParen)
+	assert.NotNil(fe.AndContinuation)
+	assert.NotNil(fe.AndContinuation.OpenParen)
+	assert.NotNil(fe.AndContinuation.CloseParen)
+	assert.Equal(2, len(fe.SubFilterExpr.FilterExpr.AndConditions))
+	assert.Equal(2, len(fe.AndContinuation.SubFilterExpr.FilterExpr.AndConditions))
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("(TRUE OR FALSE) AND (FALSE OR TRUE) AND TRUE", fe)
 	assert.Nil(err)
-	assert.Equal(2, len(fe.AndConditions))
-	assert.Equal(1, len(fe.SubFilterExpr))
-	assert.Equal(2, len(fe.SubFilterExpr[0].AndConditions))
-	assert.Equal(1, len(fe.SubFilterExpr[0].SubFilterExpr))
-	assert.Equal(1, len(fe.SubFilterExpr[0].SubFilterExpr[0].AndConditions))
+	assert.Equal(2, len(fe.SubFilterExpr.FilterExpr.AndConditions))
+	assert.NotNil(fe.AndContinuation)
+	assert.Equal(2, len(fe.AndContinuation.SubFilterExpr.FilterExpr.AndConditions))
+	assert.Equal(1, len(fe.AndContinuation.AndContinuation.FilterExpr.AndConditions))
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("(TRUE AND FALSE) OR (FALSE AND TRUE)", fe)
 	assert.Nil(err)
-	assert.Equal(2, len(fe.AndConditions))
-	assert.Equal(2, len(fe.AndConditions[0].OrConditions))
-	assert.Equal(2, len(fe.AndConditions[1].OrConditions))
+	assert.Equal(1, len(fe.SubFilterExpr.FilterExpr.AndConditions))
+	assert.Equal(2, len(fe.SubFilterExpr.FilterExpr.AndConditions[0].OrConditions))
+	assert.Equal(2, len(fe.OrContinuation.SubFilterExpr.FilterExpr.AndConditions[0].OrConditions))
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("((TRUE OR FALSE)) OR (TRUE)", fe)
 	assert.Nil(err)
-	assert.Equal(3, len(fe.AndConditions))
-	assert.Equal(0, len(fe.SubFilterExpr))
+	assert.Equal(2, len(fe.SubFilterExpr.SubFilterExpr.FilterExpr.AndConditions))
+	assert.NotNil(fe.OrContinuation)
+	assert.Equal(1, len(fe.OrContinuation.SubFilterExpr.FilterExpr.AndConditions))
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("(TRUE AND FALSE) OR (FALSE)", fe)
 	assert.Nil(err)
-	assert.Equal(2, len(fe.AndConditions))
-	assert.Equal(2, len(fe.AndConditions[0].OrConditions))
-	assert.Equal(1, len(fe.AndConditions[1].OrConditions))
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("TRUE AND (TRUE OR FALSE) AND FALSE", fe)
 	assert.Nil(err)
-	assert.Equal(1, len(fe.AndConditions))                  // TRUE (AND...)
-	assert.Equal(1, len(fe.SubFilterExpr))                  // (TRUE OR FALSE) AND FALSE
-	assert.Equal(2, len(fe.SubFilterExpr[0].AndConditions)) // (TRUE OR FALSE) (AND...)
-	assert.Equal(1, len(fe.SubFilterExpr[0].AndConditions[0].OrConditions))
-	assert.Equal(1, len(fe.SubFilterExpr[0].AndConditions[1].OrConditions))
-	assert.Equal(1, len(fe.SubFilterExpr[0].SubFilterExpr)) // FALSE
-	assert.Equal(1, len(fe.SubFilterExpr[0].SubFilterExpr[0].AndConditions))
-	assert.Equal(0, len(fe.SubFilterExpr[0].SubFilterExpr[0].SubFilterExpr))
+	assert.Equal(1, len(fe.FilterExpr.AndConditions))
+	assert.NotNil(fe.FilterExprContinuation)
+	assert.Equal(2, len(fe.FilterExprContinuation.SubFilterExpr.FilterExpr.AndConditions))
+	assert.NotNil(fe.FilterExprContinuation.AndContinuation)
+	assert.Equal(1, len(fe.FilterExprContinuation.AndContinuation.FilterExpr.AndConditions))
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("(TRUE OR FALSE) AND (FALSE OR TRUE)", fe)
 	assert.Nil(err)
-	assert.Equal(1, len(fe.AndConditions[0].OrConditions))
-	assert.Equal(1, len(fe.AndConditions[1].OrConditions))
-	assert.Equal(1, len(fe.SubFilterExpr))
-	assert.Equal(2, len(fe.AndConditions))
-	assert.Equal(2, len(fe.SubFilterExpr[0].AndConditions))
-	assert.Equal(1, len(fe.SubFilterExpr[0].AndConditions[0].OrConditions))
-	assert.Equal(1, len(fe.SubFilterExpr[0].AndConditions[1].OrConditions))
+	assert.Equal(2, len(fe.SubFilterExpr.FilterExpr.AndConditions))
+	assert.NotNil(fe.AndContinuation)
+	assert.Equal(2, len(fe.AndContinuation.SubFilterExpr.FilterExpr.AndConditions))
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 
@@ -133,18 +130,18 @@ func TestFilterExpressionParser(t *testing.T) {
 	fe = &FilterExpression{}
 	err = parser.ParseString("fieldpath.path >= field2", fe)
 	assert.Nil(err)
-	assert.Equal("fieldpath", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
-	assert.Equal("path", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
-	assert.True(fe.AndConditions[0].OrConditions[0].Operand.Op.IsGreaterThanOrEqualTo())
-	assert.False(fe.AndConditions[0].OrConditions[0].Operand.Op.IsGreaterThan())
-	assert.Equal("field2", fe.AndConditions[0].OrConditions[0].Operand.RHS.Field.String())
+	assert.Equal("fieldpath", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
+	assert.Equal("path", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
+	assert.True(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.Op.IsGreaterThanOrEqualTo())
+	assert.False(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.Op.IsGreaterThan())
+	assert.Equal("field2", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Field.String())
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("fieldpath.path IS NOT NULL", fe)
 	assert.Nil(err)
-	assert.Equal("fieldpath", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
-	assert.Equal("path", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
-	assert.True(fe.AndConditions[0].OrConditions[0].Operand.CheckOp.IsNotNull())
+	assert.Equal("fieldpath", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
+	assert.Equal("path", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
+	assert.True(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.CheckOp.IsNotNull())
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 	matchDef = trans.Transform([]Expression{expr})
@@ -162,14 +159,14 @@ func TestFilterExpressionParser(t *testing.T) {
 	fe = &FilterExpression{}
 	err = parser.ParseString("fieldpath.path = \"value\"", fe)
 	assert.Nil(err)
-	assert.Equal("fieldpath", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
-	assert.Equal("path", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
-	assert.True(fe.AndConditions[0].OrConditions[0].Operand.Op.IsEqual())
-	assert.Equal("value", fe.AndConditions[0].OrConditions[0].Operand.RHS.Value.String())
+	assert.Equal("fieldpath", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
+	assert.Equal("path", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
+	assert.True(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.Op.IsEqual())
+	assert.Equal("value", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Value.String())
 	// Test double equal is the same as single eq
 	err = parser.ParseString("fieldpath.path == \"value\"", fe)
 	assert.Nil(err)
-	assert.True(fe.AndConditions[0].OrConditions[0].Operand.Op.IsEqual())
+	assert.True(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.Op.IsEqual())
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 	matchDef = trans.Transform([]Expression{expr})
@@ -187,8 +184,8 @@ func TestFilterExpressionParser(t *testing.T) {
 	fe = &FilterExpression{}
 	err = parser.ParseString("`onePath.Only` < field2", fe)
 	assert.Nil(err)
-	assert.Equal("onePath.Only", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
-	assert.Equal("field2", fe.AndConditions[0].OrConditions[0].Operand.RHS.Field.String())
+	assert.Equal("onePath.Only", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
+	assert.Equal("field2", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Field.String())
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 	matchDef = trans.Transform([]Expression{expr})
@@ -273,9 +270,9 @@ func TestFilterExpressionParser(t *testing.T) {
 	fe = &FilterExpression{}
 	err = parser.ParseString("`onePath.Only` <> \"value\" OR `onePath.Only` <> \"value2\"", fe)
 	assert.Nil(err)
-	assert.Equal("onePath.Only", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
-	assert.True(fe.AndConditions[0].OrConditions[0].Operand.Op.IsNotEqual())
-	assert.Equal("value", fe.AndConditions[0].OrConditions[0].Operand.RHS.Value.String())
+	assert.Equal("onePath.Only", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
+	assert.True(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.Op.IsNotEqual())
+	assert.Equal("value", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Value.String())
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 	matchDef = trans.Transform([]Expression{expr})
@@ -291,10 +288,10 @@ func TestFilterExpressionParser(t *testing.T) {
 	fe = &FilterExpression{}
 	err = parser.ParseString("META().`onePath.Only` = \"value\"", fe)
 	assert.Nil(err)
-	assert.Equal("META()", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
-	assert.Equal("onePath.Only", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
-	assert.True(fe.AndConditions[0].OrConditions[0].Operand.Op.IsEqual())
-	assert.Equal("value", fe.AndConditions[0].OrConditions[0].Operand.RHS.Value.String())
+	assert.Equal("META()", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
+	assert.Equal("onePath.Only", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
+	assert.True(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.Op.IsEqual())
+	assert.Equal("value", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Value.String())
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 	matchDef = trans.Transform([]Expression{expr})
@@ -311,9 +308,9 @@ func TestFilterExpressionParser(t *testing.T) {
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("`[$%XDCRInternalMeta*%$]`.metaKey = \"value\"", fe)
-	assert.Equal("metaKey", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
-	assert.True(fe.AndConditions[0].OrConditions[0].Operand.Op.IsEqual())
-	assert.Equal("value", fe.AndConditions[0].OrConditions[0].Operand.RHS.Value.String())
+	assert.Equal("metaKey", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
+	assert.True(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.Op.IsEqual())
+	assert.Equal("value", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Value.String())
 	err = parser.ParseString("EXISTS (`[$%XDCRInternalMeta*%$]`.metaKey) AND `[$%XDCRInternalMeta*%$]`.metaKey = \"value\"", fe)
 	assert.Nil(err)
 	expr, err = fe.OutputExpression()
@@ -335,14 +332,14 @@ func TestFilterExpressionParser(t *testing.T) {
 	fe = &FilterExpression{}
 	err = parser.ParseString("`2DarrayPath`[1][-2] = fieldpath2.path2", fe)
 	assert.NotNil(err)
-	//	assert.Equal("2DarrayPath [1] [-2]", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
-	//	assert.True(fe.AndConditions[0].OrConditions[0].Operand.Op.IsEqual())
+	//	assert.Equal("2DarrayPath [1] [-2]", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
+	//	assert.True(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.Op.IsEqual())
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("`1DarrayPath`[1] = \"arrayVal1\"", fe)
 	assert.Nil(err)
-	assert.Equal("1DarrayPath [1]", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
-	assert.True(fe.AndConditions[0].OrConditions[0].Operand.Op.IsEqual())
+	assert.Equal("1DarrayPath [1]", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
+	assert.True(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.Op.IsEqual())
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 	matchDef = trans.Transform([]Expression{expr})
@@ -357,28 +354,28 @@ func TestFilterExpressionParser(t *testing.T) {
 	fe = &FilterExpression{}
 	err = parser.ParseString("arrayPath[1].path2.arrayPath3[-10].`multiword array`[20] = fieldpath2.path2", fe)
 	assert.NotNil(err)
-	//	assert.Equal("arrayPath [1]", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
-	//	assert.Equal("arrayPath", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].StrValue)
-	//	assert.Equal("path2", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].StrValue)
-	//	assert.Equal(0, len(fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].ArrayIndexes))
-	//	assert.Equal("arrayPath3 [-10]", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[2].String())
-	//	assert.Equal("multiword array [20]", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[3].String())
+	//	assert.Equal("arrayPath [1]", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
+	//	assert.Equal("arrayPath", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].StrValue)
+	//	assert.Equal("path2", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].StrValue)
+	//	assert.Equal(0, len(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].ArrayIndexes))
+	//	assert.Equal("arrayPath3 [-10]", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[2].String())
+	//	assert.Equal("multiword array [20]", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[3].String())
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("arrayPath[1].path2.arrayPath3[10].`multiword array`[20] = fieldpath2.path2", fe)
 	assert.Nil(err)
-	assert.Equal("arrayPath [1]", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
-	assert.Equal("arrayPath", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].StrValue.String())
-	assert.Equal("path2", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].StrValue.String())
-	assert.Equal(0, len(fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].ArrayIndexes))
-	assert.Equal("arrayPath3 [10]", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[2].String())
-	assert.Equal("multiword array [20]", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[3].String())
+	assert.Equal("arrayPath [1]", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
+	assert.Equal("arrayPath", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].StrValue.String())
+	assert.Equal("path2", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].StrValue.String())
+	assert.Equal(0, len(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].ArrayIndexes))
+	assert.Equal("arrayPath3 [10]", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[2].String())
+	assert.Equal("multiword array [20]", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[3].String())
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("key < PI()", fe)
 	assert.Nil(err)
-	assert.Equal("key", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
-	assert.True(*fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncNoArg.ConstFuncNoArgName.Pi)
+	assert.Equal("key", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
+	assert.True(*fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncNoArg.ConstFuncNoArgName.Pi)
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 	matchDef = trans.Transform([]Expression{expr})
@@ -392,12 +389,12 @@ func TestFilterExpressionParser(t *testing.T) {
 	fe = &FilterExpression{}
 	err = parser.ParseString("fieldpath.path <= ABS(5)", fe)
 	assert.Nil(err)
-	assert.Equal("fieldpath", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
-	assert.Equal("path", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
-	assert.True(fe.AndConditions[0].OrConditions[0].Operand.Op.IsLessThanOrEqualTo())
-	assert.Equal("ABS", fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.ConstFuncOneArgName.String())
-	assert.Equal("5", fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.String())
-	assert.Nil(fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.SubFunc)
+	assert.Equal("fieldpath", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
+	assert.Equal("path", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
+	assert.True(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.Op.IsLessThanOrEqualTo())
+	assert.Equal("ABS", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.ConstFuncOneArgName.String())
+	assert.Equal("5", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.String())
+	assert.Nil(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.SubFunc)
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 	matchDef = trans.Transform([]Expression{expr})
@@ -415,9 +412,9 @@ func TestFilterExpressionParser(t *testing.T) {
 	fe = &FilterExpression{}
 	err = parser.ParseString("DATE(fieldpath.path) = DATE(\"2019-01-01\")", fe)
 	assert.Nil(err)
-	assert.Equal("DATE", fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.ConstFuncOneArgName.String())
-	assert.Equal("2019-01-01", fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.String())
-	assert.Nil(fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.SubFunc)
+	assert.Equal("DATE", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.ConstFuncOneArgName.String())
+	assert.Equal("2019-01-01", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.String())
+	assert.Nil(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.SubFunc)
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 	matchDef = trans.Transform([]Expression{expr})
@@ -435,9 +432,9 @@ func TestFilterExpressionParser(t *testing.T) {
 	fe = &FilterExpression{}
 	err = parser.ParseString("DATE(fieldpath.path) > DATE(\"2019-01-01\") AND DATE(fieldpath.path) < DATE('2019-01-01T23:59:59.999Z') AND DATE(fieldpath.path) < DATE('2019-01-01T23:59:59.999-01:00')", fe)
 	assert.Nil(err)
-	assert.Equal("DATE", fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.ConstFuncOneArgName.String())
-	assert.Equal("2019-01-01", fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.String())
-	assert.Nil(fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.SubFunc)
+	assert.Equal("DATE", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.ConstFuncOneArgName.String())
+	assert.Equal("2019-01-01", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.String())
+	assert.Nil(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.SubFunc)
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 	matchDef = trans.Transform([]Expression{expr})
@@ -455,22 +452,22 @@ func TestFilterExpressionParser(t *testing.T) {
 	fe = &FilterExpression{}
 	err = parser.ParseString("fieldpath.path = DATE(`field with spaces`)", fe)
 	assert.Nil(err)
-	assert.Equal("fieldpath", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
-	assert.Equal("path", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
-	assert.Equal("DATE", fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.ConstFuncOneArgName.String())
-	assert.Equal("field with spaces", fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.Field.String())
-	assert.Nil(fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.SubFunc)
+	assert.Equal("fieldpath", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
+	assert.Equal("path", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
+	assert.Equal("DATE", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.ConstFuncOneArgName.String())
+	assert.Equal("field with spaces", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.Field.String())
+	assert.Nil(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.SubFunc)
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("fieldpath.path >= ABS(CEIL(PI()))", fe)
 	assert.Nil(err)
-	assert.Equal("fieldpath", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
-	assert.Equal("path", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
-	assert.Equal("ABS", fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.ConstFuncOneArgName.String())
-	assert.Nil(fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.Argument)
-	assert.NotNil(fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.SubFunc)
-	assert.NotNil(fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.SubFunc.ConstFuncOneArg)
-	assert.NotNil(fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.SubFunc.ConstFuncOneArg.Argument.SubFunc.ConstFuncNoArg)
+	assert.Equal("fieldpath", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
+	assert.Equal("path", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
+	assert.Equal("ABS", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.ConstFuncOneArgName.String())
+	assert.Nil(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.Argument)
+	assert.NotNil(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.SubFunc)
+	assert.NotNil(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.SubFunc.ConstFuncOneArg)
+	assert.NotNil(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncOneArg.Argument.SubFunc.ConstFuncOneArg.Argument.SubFunc.ConstFuncNoArg)
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 	matchDef = trans.Transform([]Expression{expr})
@@ -527,22 +524,22 @@ func TestFilterExpressionParser(t *testing.T) {
 	fe = &FilterExpression{}
 	err = parser.ParseString("fieldpath.path <> POW(ABS(CEIL(PI())),2)", fe)
 	assert.Nil(err)
-	assert.Equal("fieldpath", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
-	assert.Equal("path", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
-	assert.True(fe.AndConditions[0].OrConditions[0].Operand.Op.IsNotEqual())
-	assert.Equal("POW", fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncTwoArgs.ConstFuncTwoArgsName.String())
-	assert.Equal("ABS", fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncTwoArgs.Argument0.SubFunc.ConstFuncOneArg.ConstFuncOneArgName.String())
+	assert.Equal("fieldpath", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
+	assert.Equal("path", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
+	assert.True(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.Op.IsNotEqual())
+	assert.Equal("POW", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncTwoArgs.ConstFuncTwoArgsName.String())
+	assert.Equal("ABS", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncTwoArgs.Argument0.SubFunc.ConstFuncOneArg.ConstFuncOneArgName.String())
 	// Test second not equals
 	err = parser.ParseString("fieldpath.path != POW(ABS(CEIL(PI())),2)", fe)
 	assert.Nil(err)
-	assert.True(fe.AndConditions[0].OrConditions[0].Operand.Op.IsNotEqual())
+	assert.True(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.Op.IsNotEqual())
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("REGEXP_CONTAINS(`[$%XDCRInternalKey*%$]`, \"^xyz*\")", fe)
 	assert.Nil(err)
-	assert.Equal("REGEXP_CONTAINS", fe.AndConditions[0].OrConditions[0].Operand.BooleanExpr.BooleanFunc.BooleanFuncTwoArgs.BooleanFuncTwoArgsName.String())
-	assert.Equal("[$%XDCRInternalKey*%$]", fe.AndConditions[0].OrConditions[0].Operand.BooleanExpr.BooleanFunc.BooleanFuncTwoArgs.Argument0.Field.String())
-	assert.Equal("^xyz*", fe.AndConditions[0].OrConditions[0].Operand.BooleanExpr.BooleanFunc.BooleanFuncTwoArgs.Argument1.Argument.String())
+	assert.Equal("REGEXP_CONTAINS", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.BooleanExpr.BooleanFunc.BooleanFuncTwoArgs.BooleanFuncTwoArgsName.String())
+	assert.Equal("[$%XDCRInternalKey*%$]", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.BooleanExpr.BooleanFunc.BooleanFuncTwoArgs.Argument0.Field.String())
+	assert.Equal("^xyz*", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.BooleanExpr.BooleanFunc.BooleanFuncTwoArgs.Argument1.Argument.String())
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 	matchDef = trans.Transform([]Expression{expr})
@@ -576,15 +573,15 @@ func TestFilterExpressionParser(t *testing.T) {
 	fe = &FilterExpression{}
 	err = parser.ParseString("fieldpath.path = POW(ABS(CEIL(PI())),2) AND REGEXP_CONTAINS(fieldPath2, \"^abc*$\")", fe)
 	assert.Nil(err)
-	assert.Equal("fieldpath", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
-	assert.Equal("path", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
-	assert.Equal("POW", fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncTwoArgs.ConstFuncTwoArgsName.String())
-	assert.Equal("ABS", fe.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncTwoArgs.Argument0.SubFunc.ConstFuncOneArg.ConstFuncOneArgName.String())
-	assert.Equal(1, len(fe.AndConditions))
-	assert.Equal(2, len(fe.AndConditions[0].OrConditions))
-	assert.NotNil(fe.AndConditions[0].OrConditions[1].Operand.BooleanExpr)
-	assert.Equal("fieldPath2", fe.AndConditions[0].OrConditions[1].Operand.BooleanExpr.BooleanFunc.BooleanFuncTwoArgs.Argument0.String())
-	assert.Equal("^abc*$", fe.AndConditions[0].OrConditions[1].Operand.BooleanExpr.BooleanFunc.BooleanFuncTwoArgs.Argument1.Argument.String())
+	assert.Equal("fieldpath", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
+	assert.Equal("path", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[1].String())
+	assert.Equal("POW", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncTwoArgs.ConstFuncTwoArgsName.String())
+	assert.Equal("ABS", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.RHS.Func.ConstFuncTwoArgs.Argument0.SubFunc.ConstFuncOneArg.ConstFuncOneArgName.String())
+	assert.Equal(1, len(fe.FilterExpr.AndConditions))
+	assert.Equal(2, len(fe.FilterExpr.AndConditions[0].OrConditions))
+	assert.NotNil(fe.FilterExpr.AndConditions[0].OrConditions[1].Operand.BooleanExpr)
+	assert.Equal("fieldPath2", fe.FilterExpr.AndConditions[0].OrConditions[1].Operand.BooleanExpr.BooleanFunc.BooleanFuncTwoArgs.Argument0.String())
+	assert.Equal("^abc*$", fe.FilterExpr.AndConditions[0].OrConditions[1].Operand.BooleanExpr.BooleanFunc.BooleanFuncTwoArgs.Argument1.Argument.String())
 
 	var testStr string = "`field.Path` = \"value\""
 	_, err = GetFilterExpressionMatcher(testStr)
@@ -633,9 +630,9 @@ func TestFilterExpressionParser(t *testing.T) {
 	fe = &FilterExpression{}
 	err = parser.ParseString("achievements * 10 = 10", fe)
 	assert.Nil(err)
-	assert.Equal("achievements", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
-	assert.NotNil(fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.MathOp.Multiply)
-	assert.Equal("10", fe.AndConditions[0].OrConditions[0].Operand.LHS.Field.MathValue.String())
+	assert.Equal("achievements", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.Path[0].String())
+	assert.NotNil(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.MathOp.Multiply)
+	assert.Equal("10", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Field.MathValue.String())
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 	matchDef = trans.Transform([]Expression{expr})
@@ -651,11 +648,11 @@ func TestFilterExpressionParser(t *testing.T) {
 	fe = &FilterExpression{}
 	err = parser.ParseString("ABS(-achievements[2]*10) > 0", fe)
 	assert.Nil(err)
-	assert.NotNil(fe.AndConditions[0].OrConditions[0].Operand.LHS.Func.ConstFuncOneArg.Argument.Field.MathNeg)
-	assert.Equal("achievements", fe.AndConditions[0].OrConditions[0].Operand.LHS.Func.ConstFuncOneArg.Argument.Field.Path[0].StrValue.String())
-	assert.Equal("[2]", fe.AndConditions[0].OrConditions[0].Operand.LHS.Func.ConstFuncOneArg.Argument.Field.Path[0].ArrayIndexes[0].String())
-	assert.NotNil(fe.AndConditions[0].OrConditions[0].Operand.LHS.Func.ConstFuncOneArg.Argument.Field.MathOp.Multiply)
-	assert.Equal("10", fe.AndConditions[0].OrConditions[0].Operand.LHS.Func.ConstFuncOneArg.Argument.Field.MathValue.String())
+	assert.NotNil(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Func.ConstFuncOneArg.Argument.Field.MathNeg)
+	assert.Equal("achievements", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Func.ConstFuncOneArg.Argument.Field.Path[0].StrValue.String())
+	assert.Equal("[2]", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Func.ConstFuncOneArg.Argument.Field.Path[0].ArrayIndexes[0].String())
+	assert.NotNil(fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Func.ConstFuncOneArg.Argument.Field.MathOp.Multiply)
+	assert.Equal("10", fe.FilterExpr.AndConditions[0].OrConditions[0].Operand.LHS.Func.ConstFuncOneArg.Argument.Field.MathValue.String())
 	expr, err = fe.OutputExpression()
 	assert.Nil(err)
 	matchDef = trans.Transform([]Expression{expr})
@@ -667,23 +664,59 @@ func TestFilterExpressionParser(t *testing.T) {
 	match, err = m.Match(udMarsh)
 	assert.True(match)
 
+	// Beer sample
+	beer := map[string]interface{}{
+		"abv":         5.2,
+		"brewery_id":  "big_buck_brewery",
+		"category":    "North American Ale",
+		"description": "A standard American-style beer and our flagship brand.  A small amount of corn is added to the grist to give the brew a smooth character.  Features a rich, golden color and a light malt character balanced with a mild dose of hops.",
+		"ibu":         0,
+		"name":        "Big Buck Beer",
+		"srm":         0,
+		"style":       "American-Style Pale Ale",
+		"type":        "beer",
+		"upc":         0,
+		"updated":     "2019-03-22 20:00:20",
+	}
+	fe = &FilterExpression{}
+	err = parser.ParseString("(country == \"United States\" OR country = \"Canada\" AND type=\"brewery\") OR (type=\"beer\" AND DATE(updated) >= DATE(\"2019-01-18\"))", fe)
+	assert.Nil(err)
+	expr, err = fe.OutputExpression()
+
+	assert.Nil(err)
+	matchDef = trans.Transform([]Expression{expr})
+	assert.NotNil(matchDef)
+	udMarsh, _ = json.Marshal(beer)
+	match, err = m.Match(udMarsh)
+	assert.True(match)
+
+	fe = &FilterExpression{}
+	err = parser.ParseString("((country == \"United States\" OR country = \"Canada\") AND type=\"brewery\") OR (type=\"beer\" AND DATE(updated) >= DATE(\"2019-01-18\"))", fe)
+	assert.Nil(err)
+	expr, err = fe.OutputExpression()
+
+	marshalledData := []byte(`{"[$%XDCRInternalKey*%$]":"big_buck_brewery-big_buck_beer","[$%XDCRInternalMeta*%$]":{},"abv":5.2,"brewery_id":"big_buck_brewery","category":"North American Ale","description":"A standard American-style beer and our flagship brand.  A small amount of corn is added to the grist to give the brew a smooth character.  Features a rich, golden color and a light malt character balanced with a mild dose of hops.","ibu":0,"name":"Big Buck Beer","srm":0,"style":"American-Style Pale Ale","type":"beer","upc":0,"updated":"2019-03-22 20:00:20"}`)
+	fe = &FilterExpression{}
+	err = parser.ParseString(`((county = "United States" OR country = "Canada") AND type="brewery") OR (type="beer" AND DATE(updated) >= DATE("2019-01-01"))`, fe)
+	assert.Nil(err)
+	expr, err = fe.OutputExpression()
+	assert.Nil(err)
+	matchDef = trans.Transform([]Expression{expr})
+	assert.NotNil(matchDef)
+	match, err = m.Match(marshalledData)
+	assert.True(match)
+
 	// Negative
 	_, _, err = NewFilterExpressionParser("fieldpath.`path = fieldPath2")
 	assert.NotNil(err)
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("(TRUE) OR FALSE)", fe)
-	assert.Nil(err)
-	expr, err = fe.OutputExpression()
 	assert.NotNil(err)
-	assert.True(strings.Contains(err.Error(), ErrorMalformedParenthesis.Error()))
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("(((TRUE) OR FALSE) OR FALSE))", fe)
-	assert.Nil(err)
-	expr, err = fe.OutputExpression()
 	assert.NotNil(err)
-	assert.True(strings.Contains(err.Error(), ErrorMalformedParenthesis.Error()))
 
 	fe = &FilterExpression{}
 	err = parser.ParseString("TRUE", fe)
@@ -701,28 +734,6 @@ func TestFilterExpressionParser(t *testing.T) {
 	fe = &FilterExpression{}
 	err = parser.ParseString("achievement * 2 +1", fe)
 	assert.NotNil(err)
-
-	// Test unicode
-	_, fe, err = NewFilterExpressionParser("face == \"😂\"")
-	expr, err = fe.OutputExpression()
-	matchDef = trans.Transform([]Expression{expr})
-	assert.Nil(err)
-	m = NewFastMatcher(matchDef)
-	userData = map[string]interface{}{
-		"face": "😂",
-		"中文":   "白人看不懂",
-	}
-	udMarsh, _ = json.Marshal(userData)
-	match, err = m.Match(udMarsh)
-	assert.True(match)
-
-	_, fe, err = NewFilterExpressionParser("中文 IS NOT NULL AND REGEXP_CONTAINS(中文, \"白人\")")
-	expr, err = fe.OutputExpression()
-	matchDef = trans.Transform([]Expression{expr})
-	assert.Nil(err)
-	m = NewFastMatcher(matchDef)
-	match, err = m.Match(udMarsh)
-	assert.True(match)
 
 	// Typos
 	_, _, err = NewFilterExpressionParser("REGEX_CONTAINS(KEY, \"something\")")
@@ -771,7 +782,7 @@ func TestFilterExpressionParser(t *testing.T) {
 	match, err = m.Match(udMarsh)
 	assert.True(match)
 
-	// Invalid parenthesis
+	// Invalid parenthesis - this is caught by the parenthesis check
 	_, fe, err = NewFilterExpressionParser("((TRUE OR FALSE () AND TRUE))")
 	_, err = fe.OutputExpression()
 	assert.NotNil(err)


### PR DESCRIPTION
…ive parsing of parenthesis

Previous grammar led to incorrectly parsed logic
With the new logic, it should output the correct AST based on correctly parsing all of the parenthesis

Example output:
```
(country == "United States" OR country = "Canada" AND type="brewery") OR (type="beer" AND DATE(updated) >= DATE("2019-01-18"))

ND Entry:
( country = United States OR country = Canada AND type = brewery ) OR ( type = beer AND DATE( updated ) >= DATE( 2019-01-18 ) )
ND ActualOutput:
    $doc.country = United States
  OR
      $doc.country = Canada
    AND
      $doc.type = brewery
OR
    $doc.type = beer
  AND
    func:date($doc.updated) >= func:date(2019-01-18)
```

and

```
((country == "United States" OR country = "Canada") AND type="brewery") OR (type="beer" AND DATE(updated) >= DATE("2019-01-18"))

ND Entry:
( ( county = United States OR country = Canada ) AND type = brewery ) OR ( type = beer AND DATE( updated ) >= DATE( 2019-01-01 ) )
ND ActualOutput:
      $doc.county = United States
    OR
      $doc.country = Canada
  AND
    $doc.type = brewery
OR
    $doc.type = beer
  AND
    func:date($doc.updated) >= func:date(2019-01-01)
```