### PR TITLE
Add support for JsonTokenizer to be publicly accessible

### DIFF
--- a/jsontokenizer.go
+++ b/jsontokenizer.go
@@ -484,5 +484,20 @@ DataLoop:
 	tkn.pos = dataPos
 
 	return tokenType, tokenData, tokenDataLen, nil
+}
 
+func (tkn tokenType) IsTokenEnd() bool {
+	return tkn == tknEnd
+}
+
+func (tkn tokenType) IsString() bool {
+	return tkn == tknString
+}
+
+func (tkn tokenType) IsObjEnd() bool {
+	return tkn == tknObjectEnd
+}
+
+func NewJsonTokenizer() *jsonTokenizer {
+	return &jsonTokenizer{}
 }


### PR DESCRIPTION
XDCR has a use-case wherein, it has to parse a nested JSON system xattr called "_mou", written by sync-gateway/mobile (See [MB-60897](https://issues.couchbase.com/browse/MB-60897) / [CBG-3803](https://issues.couchbase.com/browse/CBG-3803) for more information) as part of XDCR/Mobile Coexistence project. Given that XDCR already uses gojsonsm for its filtering needs, it can also utilize the json tokenizer in itself for parsing any JSON xattr as well. 

But the json tokenizer itself isn't publicly accessible right now. This PR will add a public constructor and a few helper functions, allowing XDCR to create a stand-alone JSON tokenizer (and not as part of any "matcher"), without modifying anything that already exists.